### PR TITLE
cmd+/ 'comment' keymap in JSP now uses JSP-style comments rather than XM...

### DIFF
--- a/scoped-properties/language-java.cson
+++ b/scoped-properties/language-java.cson
@@ -13,3 +13,10 @@
 '.source.java-properties':
   'editor':
     'commentStart': '# '
+'.text.jsp':
+  'editor':
+    'commentStart': '<%-- '
+    'commentEnd': ' --%>'
+    'foldEndPattern': '^\\s*(</[^>]+>|[/%]>|-->)\\s*$'
+    'increaseIndentPattern': '^\\s*<(([^!/?]|%)(?!.+?([/%]>|</.+?>))|[%!]--\\s*$)'
+    'decreaseIndentPattern': '^\\s*(</[^>]+>|-->|--%>)'


### PR DESCRIPTION
This is to address issue #3.
- I first referred to the cmd+/ keymap from the [language-xml](https://github.com/atom/language-xml/blob/master/scoped-properties/language-xml.cson) package. 
- I then updated commentStart and commentEnd with the correct JSP syntax
- I lastly tested in Atom developer mode.
