### PR TITLE
Update the RegExp for constant.numeric.java.

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -431,7 +431,7 @@
         'name': 'variable.language.java'
       }
       {
-        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\\b'
+        'match': '\\b((0(x|X)[0-9a-fA-F]+)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\\b'
         'name': 'constant.numeric.java'
       }
       {


### PR DESCRIPTION
The existing RegExp recognizes invalid hexadecimals like `int x = 0x;`.

However, the [specification](http://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-HexNumeral) says that "A hexadecimal numeral consists of the leading ASCII characters 0x or 0X followed by one or more ASCII hexadecimal digits [...]".

This change essentially makes the `[0-9a-fA-F]` group set non-optional.
