### PR TITLE
Recognizes binary integer literals.

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -431,7 +431,7 @@
         'name': 'variable.language.java'
       }
       {
-        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\\b'
+        'match': '\\b((0(b|B)[01]+)|(0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\\b'
         'name': 'constant.numeric.java'
       }
       {


### PR DESCRIPTION
Binary integer literals like `0x10101` have been introduced in Java 7.
