### PR TITLE
Allow comments inside Enum declarations

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -478,6 +478,9 @@
           }
         ]
       }
+      {
+        'include': '#comments'
+      }
     ]
   'keywords':
     'patterns': [

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -26,3 +26,22 @@ describe 'Java grammar', ->
 
     expect(lines[0][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
     expect(lines[0][2]).toEqual value: 'Thing', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
+
+  it 'tokenizes enums', ->
+    lines = grammar.tokenizeLines '''
+      enum Letters {
+        /** Comment about A */
+        A,
+
+        // Comment about B
+        B
+      }
+    '''
+
+    comment = ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    commentDefinition = comment.concat('punctuation.definition.comment.java')
+
+    expect(lines[1][1]).toEqual value: '/*', scopes: commentDefinition
+    expect(lines[1][2]).toEqual value: '* Comment about A ', scopes: comment
+    expect(lines[1][3]).toEqual value: '*/', scopes: commentDefinition
+    expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']


### PR DESCRIPTION
Fundamentally same fix as [textmate's](https://github.com/textmate/java.tmbundle/commit/ba10e91f122c25ee0bebd60479de6ff4d70a565b).

Fixes #13