### PR TITLE
Fix overeager enum tokenization

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -331,6 +331,9 @@
         'include': '#comments'
       }
       {
+        'include': '#enums'
+      }
+      {
         'include': '#class'
       }
       {
@@ -447,34 +450,34 @@
       }
     ]
   'enums':
-    'begin': '^(?=\\s*[A-Z0-9_]+\\s*({|\\(|,))'
-    'end': '(?=;|})'
+    'begin': '^\\s*(enum)\\s+(\\w+)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.modifier.java'
+      '2':
+        'name': 'entity.name.type.enum.java'
+    'end': '}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.enum.end.java'
+    'name': 'meta.enum.java'
     'patterns': [
       {
-        'begin': '\\w+'
+        'include': '#parens'
+      }
+      {
+        'begin': '{'
         'beginCaptures':
           '0':
-            'name': 'constant.other.enum.java'
-        'end': '(?=,|;|})'
-        'name': 'meta.enum.java'
+            'name': 'punctuation.section.enum.begin.java'
+        'end': '(?=})'
         'patterns': [
           {
-            'include': '#parens'
+            'match': '\\w+'
+            'name': 'constant.other.enum.java'
           }
           {
-            'begin': '{'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.enum.begin.java'
-            'end': '}'
-            'endCaptures':
-              '0':
-                'name': 'punctuation.section.enum.end.java'
-            'patterns': [
-              {
-                'include': '#class-body'
-              }
-            ]
+            'include': '#class-body'
           }
         ]
       }
@@ -625,7 +628,7 @@
           '0':
             'name': 'punctuation.section.method.begin.java'
         'end': '(?=})'
-        'name': 'meta.method.body.java'
+        'contentName': 'meta.method.body.java'
         'patterns': [
           {
             'include': '#code'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -38,10 +38,33 @@ describe 'Java grammar', ->
       }
     '''
 
-    comment = ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    comment = ['source.java', 'meta.enum.java', 'comment.block.java']
     commentDefinition = comment.concat('punctuation.definition.comment.java')
 
+    expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[0][2]).toEqual value: 'Letters', scopes: ['source.java', 'meta.enum.java', 'entity.name.type.enum.java']
+    expect(lines[0][4]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.begin.java']
     expect(lines[1][1]).toEqual value: '/*', scopes: commentDefinition
     expect(lines[1][2]).toEqual value: '* Comment about A ', scopes: comment
     expect(lines[1][3]).toEqual value: '*/', scopes: commentDefinition
-    expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[6][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.java']
+
+  it 'tokenizes methods', ->
+    lines = grammar.tokenizeLines '''
+      class A
+      {
+        A(int a, int b)
+        {
+        }
+      }
+    '''
+
+    expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[2][2]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java']
+    expect(lines[2][3]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.array.java']
+    expect(lines[2][5]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[2][6]).toEqual value: ', ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java']
+    expect(lines[2][10]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java']
+    expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.java']
+    expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.java']


### PR DESCRIPTION
Previously, methods such as `A(int a, int b) { }` were being incorrectly tokenized as enums.

Fixes #17