### PR TITLE
Add Java 8 Arrow (->) to keywords/operators

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -505,7 +505,7 @@
       }
       {
         'match': '(->)'
-        'name': 'keyword.operator.arrow.java'
+        'name': 'storage.type.function.arrow.java'
       }
       {
         'match': '(<<|>>>?|~|\\^)'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -554,7 +554,7 @@
   'lambda-expression':
     'patterns': [
       {
-        'match': '(->)'
+        'match': '->'
         'name': 'storage.type.function.arrow.java'
       }
     ]

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -364,6 +364,9 @@
         'include': '#anonymous-classes-and-new'
       }
       {
+        'include': '#lambda-expression'
+      }
+      {
         'include': '#keywords'
       }
       {
@@ -504,10 +507,6 @@
         'name': 'keyword.operator.java'
       }
       {
-        'match': '(->)'
-        'name': 'storage.type.function.arrow.java'
-      }
-      {
         'match': '(<<|>>>?|~|\\^)'
         'name': 'keyword.operator.bitwise.java'
       }
@@ -550,6 +549,13 @@
       {
         'match': ';'
         'name': 'punctuation.terminator.java'
+      }
+    ]
+  'lambda-expression':
+    'patterns': [
+      {
+        'match': '(->)'
+        'name': 'storage.type.function.arrow.java'
       }
     ]
   'method-call':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -504,6 +504,10 @@
         'name': 'keyword.operator.java'
       }
       {
+        'match': '(->)'
+        'name': 'keyword.operator.arrow.java'
+      }
+      {
         'match': '(<<|>>>?|~|\\^)'
         'name': 'keyword.operator.bitwise.java'
       }

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -68,3 +68,15 @@ describe 'Java grammar', ->
     expect(lines[2][10]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java']
     expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.java']
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.java']
+
+  it 'tokenizes arrow operator', ->
+    lines = grammar.tokenizeLines '''
+      (String s1) -> s1.length() - outer.length();
+    '''
+
+    expect(lines[0][1]).toEqual value: 'String', scopes: ['source.java', 'storage.type.java']
+    expect(lines[0][5]).toEqual value: '->', scopes: ['source.java', 'keyword.operator.arrow.java']
+    expect(lines[0][7]).toEqual value: '.', scopes: ['source.java', 'keyword.operator.dereference.java']
+    expect(lines[0][9]).toEqual value: '(', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.begin.java']
+    expect(lines[0][10]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.end.java']
+    expect(lines[0][12]).toEqual value: '-', scopes: ['source.java', 'keyword.operator.arithmetic.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -73,7 +73,7 @@ describe 'Java grammar', ->
     {tokens} = grammar.tokenizeLine '(String s1) -> s1.length() - outer.length();'
 
     expect(tokens[1]).toEqual value: 'String', scopes: ['source.java', 'storage.type.java']
-    expect(tokens[5]).toEqual value: '->', scopes: ['source.java', 'keyword.operator.arrow.java']
+    expect(tokens[5]).toEqual value: '->', scopes: ['source.java', 'storage.type.function.arrow.java']
     expect(tokens[7]).toEqual value: '.', scopes: ['source.java', 'keyword.operator.dereference.java']
     expect(tokens[9]).toEqual value: '(', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.begin.java']
     expect(tokens[10]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.end.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -70,13 +70,11 @@ describe 'Java grammar', ->
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.java']
 
   it 'tokenizes arrow operator', ->
-    lines = grammar.tokenizeLines '''
-      (String s1) -> s1.length() - outer.length();
-    '''
+    {tokens} = grammar.tokenizeLine '(String s1) -> s1.length() - outer.length();'
 
-    expect(lines[0][1]).toEqual value: 'String', scopes: ['source.java', 'storage.type.java']
-    expect(lines[0][5]).toEqual value: '->', scopes: ['source.java', 'keyword.operator.arrow.java']
-    expect(lines[0][7]).toEqual value: '.', scopes: ['source.java', 'keyword.operator.dereference.java']
-    expect(lines[0][9]).toEqual value: '(', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.begin.java']
-    expect(lines[0][10]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.end.java']
-    expect(lines[0][12]).toEqual value: '-', scopes: ['source.java', 'keyword.operator.arithmetic.java']
+    expect(tokens[1]).toEqual value: 'String', scopes: ['source.java', 'storage.type.java']
+    expect(tokens[5]).toEqual value: '->', scopes: ['source.java', 'keyword.operator.arrow.java']
+    expect(tokens[7]).toEqual value: '.', scopes: ['source.java', 'keyword.operator.dereference.java']
+    expect(tokens[9]).toEqual value: '(', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.begin.java']
+    expect(tokens[10]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.method-parameters.end.java']
+    expect(tokens[12]).toEqual value: '-', scopes: ['source.java', 'keyword.operator.arithmetic.java']


### PR DESCRIPTION
Currently the arrow is separated into the minus and greater-than
operators. Combining them as a single operator is more correct, and is
required for the Hasklig font arrow to render correctly