### PR TITLE
Added snippet for serialVersionUID

### DIFF
--- a/snippets/language-java.cson
+++ b/snippets/language-java.cson
@@ -50,6 +50,9 @@
   'return':
     'prefix': 're'
     'body': 'return '
+  'serialVersionUID':
+    'prefix': 'se'
+    'body': 'private static final long serialVersionUID = ${1:42}l;$0'
   'static':
     'prefix': 'st'
     'body': 'static '


### PR DESCRIPTION
I never seem to remember all the modifiers at first, and when I've started googling and actually do remember them it's quicker anyway to copy from the first hit.

Having it as a snippet would be awesome for me, and I suspect many others.

![serial-snippet](https://cloud.githubusercontent.com/assets/933880/15142455/667f6340-16a5-11e6-8590-60fbc9916008.gif)
