### PR TITLE
Correctly match primitive types

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -862,7 +862,7 @@
   'primitive-arrays':
     'patterns': [
       {
-        'begin': '\\b(void|boolean|byte|char|short|int|float|long|double)\\b\\s*(?=\\[)'
+        'begin': '\\b(void|boolean|byte|char|short|int|float|long|double)\\s*(?=\\[)'
         'end': '(?!\\s*\\[)'
         'name': 'storage.type.primitive.array.java'
         'patterns': [

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -325,3 +325,11 @@ describe 'Java grammar', ->
     expect(tokens[17]).toEqual value: 'initialized', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'meta.definition.variable.name.java']
     expect(tokens[19]).toEqual value: '=', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'keyword.operator.assignment.java']
     expect(tokens[21]).toEqual value: '12', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'constant.numeric.java']
+
+  it 'tokenizes primitives', ->
+    {tokens} = grammar.tokenizeLine 'private int plainInt'
+    expect(tokens[2]).toEqual value: 'int', scopes: ['source.java', 'storage.type.primitive.java']
+
+  it 'tokenizes primitive arrays', ->
+    {tokens} = grammar.tokenizeLine 'private int[] intarray'
+    expect(tokens[2]).toEqual value: 'int', scopes: ['source.java', 'storage.type.primitive.array.java']


### PR DESCRIPTION
A array of a primitive type may not be followed by a word
boundary. For example

```java
int[] myArray = new int[42];
```

Is perfectly valid.

So is also

```java
int     [] myArray;
```

so zero or more whitespaces after `int`. `\s*` should
be the right separator.

Fixes #36