### PR TITLE
Member declaration cannot end after name

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -954,7 +954,7 @@
             \\s+
             (?!private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final|def|void|boolean|byte|char|short|int|float|long|double)
             [\\w\\d_<>\\[\\],\\?][\\w\\d_<>\\[\\],\\?\\s]*
-            (?:=|$)
+            \\s*=?
           ))
         '''
         'end': '(?=;)'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -313,3 +313,15 @@ describe 'Java grammar', ->
     {tokens} = grammar.tokenizeLine 'instanceof'
 
     expect(tokens[0]).toEqual value: 'instanceof', scopes: ['source.java', 'keyword.operator.instanceof.java']
+
+  it 'tokenizes class fields', ->
+    {tokens} = grammar.tokenizeLine '''
+      class A {
+        private int uninitialized;
+        private int initialized = 12;
+      }
+    '''
+    expect(tokens[10]).toEqual value: 'uninitialized', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'meta.definition.variable.name.java']
+    expect(tokens[17]).toEqual value: 'initialized', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'meta.definition.variable.name.java']
+    expect(tokens[19]).toEqual value: '=', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'keyword.operator.assignment.java']
+    expect(tokens[21]).toEqual value: '12', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'constant.numeric.java']


### PR DESCRIPTION
After a member's been declared it *may* be defined, it cannot
be endOfLine ($) though.

Now this will be matched and scoped properly:

  private int uninitialized;
  private int initialized = 12;

Fixes #35