### PR TITLE
Do not set scope "return-type" to space after return type

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -700,7 +700,7 @@
       }
       {
         'begin': '(?=\\w.*\\s+\\w+\\s*\\()'
-        'end': '(?=\\w+\\s*\\()'
+        'end': '(?=\\s+\\w+\\s*\\()'
         'name': 'meta.method.return-type.java'
         'patterns': [
           {

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -46,6 +46,7 @@ describe 'Java grammar', ->
     expect(lines[2][5]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
     expect(lines[2][6]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
     expect(lines[2][7]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
+    expect(lines[2][8]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java']
     expect(lines[2][10]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java']
     expect(lines[2][12]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.object.array.java', 'punctuation.bracket.square.java']
     expect(lines[2][13]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.object.array.java', 'punctuation.bracket.square.java']


### PR DESCRIPTION
The space after the storage type in a method return value should not be tagged with `meta.method.return-type.java`.

Before
![screen shot 2016-05-24 at 4 07 39 pm](https://cloud.githubusercontent.com/assets/933880/15506911/ad271642-21c9-11e6-8084-617dab6f5649.png)

After
![screen shot 2016-05-24 at 4 06 51 pm](https://cloud.githubusercontent.com/assets/933880/15506938/c9527744-21c9-11e6-9d4d-96883727a3c4.png)
