### PR TITLE
Just because a variable is capitalized doesn't mean it's constant

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -966,12 +966,6 @@
           {
             'captures':
               '1':
-                'name': 'constant.variable.java'
-            'match': '([A-Z_0-9]+)\\s+(?=\\=)'
-          }
-          {
-            'captures':
-              '1':
                 'name': 'meta.definition.variable.name.java'
             'match': '(\\w[^\\s,]*)\\s+(?=\\=)'
           }


### PR DESCRIPTION
Having this rule here means it did not get the scope
`meta.definition.variable.name.java` which is what we're sure it is.

Possibly the scope `constant.variable.java` should be added if
there is a storage modifier `final`. I'll leave that for another PR.