### PR TITLE
Add scopes to try-catch-finally blocks

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -494,16 +494,23 @@
     'patterns': [
       # try block
       {
-        'begin': '(\\btry\\b)'
+        'begin': '\\btry\\b'
         'beginCaptures':
-          '1':
+          '0':
             'name': 'keyword.control.try.java'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.try.end.bracket.curly.java'
+        'name': 'meta.try.java'
         'patterns': [
           {
             'begin': '{'
             'beginCaptures':
               '0':
                 'name':'punctuation.section.try.begin.bracket.curly.java'
+            'end': '(?=})'
+            'contentName': 'meta.try.body.java'
             'patterns': [
               {
                 'include': '#variables'
@@ -512,15 +519,8 @@
                 'include': '#code'
               }
             ]
-            'end': '(?=})'
-            'contentName': 'meta.try.body.java'
           }
         ]
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.try.end.bracket.curly.java'
-        'name': 'meta.try.java'
       }
       # catch block (with "parameters")
       {
@@ -528,22 +528,27 @@
         'beginCaptures':
           '1':
             'name': 'keyword.control.catch.java'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.catch.end.bracket.curly.java'
+        'name': 'meta.catch.java'
         'patterns': [
           {
             'begin': '\\('
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.parameters.begin.bracket.round.java'
-            'patterns': [
-              {
-                'include': '#parameters'
-              }
-            ]
             'end': '\\)'
             'endCaptures':
               '0':
                 'name': 'punctuation.definition.parameters.end.bracket.round.java'
             'contentName': 'meta.catch.parameters.java'
+            'patterns': [
+              {
+                'include': '#parameters'
+              }
+            ]
           }
           {
             'begin': '{'
@@ -562,11 +567,6 @@
             'contentName': 'meta.catch.body.java'
           }
         ]
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.catch.end.bracket.curly.java'
-        'name': 'meta.catch.java'
       }
       # finally block
       {
@@ -574,12 +574,19 @@
         'beginCaptures':
           '1':
             'name': 'keyword.control.finally.java'
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.finally.end.bracket.curly.java'
+        'name': 'meta.finally.java'
         'patterns': [
           {
             'begin': '{'
             'beginCaptures':
               '0':
                 'name':'punctuation.section.finally.begin.bracket.curly.java'
+            'end': '(?=})'
+            'contentName': 'meta.finally.body.java'
             'patterns': [
               {
                 'include': '#variables'
@@ -588,15 +595,8 @@
                 'include': '#code'
               }
             ]
-            'end': '(?=})'
-            'contentName': 'meta.finally.body.java'
           }
         ]
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.finally.end.bracket.curly.java'
-        'name': 'meta.finally.java'
       }
     ]
   'constants-and-special-vars':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -392,6 +392,9 @@
         ]
       }
       {
+        'include': '#try-catch-finally'
+      }
+      {
         'include': '#assertions'
       }
       {
@@ -485,6 +488,115 @@
             'name': 'comment.line.double-slash.java'
           }
         ]
+      }
+    ]
+  'try-catch-finally':
+    'patterns': [
+      # try block
+      {
+        'begin': '(\\btry\\b)'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.control.try.java'
+        'patterns': [
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name':'punctuation.section.try.begin.bracket.curly.java'
+            'patterns': [
+              {
+                'include': '#variables'
+              }
+              {
+                'include': '#code'
+              }
+            ]
+            'end': '(?=})'
+            'contentName': 'meta.try.body.java'
+          }
+        ]
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.try.end.bracket.curly.java'
+        'name': 'meta.try.java'
+      }
+      # catch block (with "parameters")
+      {
+        'begin': '(\\bcatch\\b)\\s*(?=\\([^ ]+\\s*[^)]+\\))'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.control.catch.java'
+        'patterns': [
+          {
+            'begin': '\\('
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.parameters.begin.bracket.round.java'
+            'patterns': [
+              {
+                'include': '#parameters'
+              }
+            ]
+            'end': '\\)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.parameters.end.bracket.round.java'
+            'contentName': 'meta.catch.parameters.java'
+          }
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name':'punctuation.section.catch.begin.bracket.curly.java'
+            'patterns': [
+              {
+                'include': '#variables'
+              }
+              {
+                'include': '#code'
+              }
+            ]
+            'end': '(?=})'
+            'contentName': 'meta.catch.body.java'
+          }
+        ]
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.catch.end.bracket.curly.java'
+        'name': 'meta.catch.java'
+      }
+      # finally block
+      {
+        'begin': '(\\bfinally\\b)'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.control.finally.java'
+        'patterns': [
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name':'punctuation.section.finally.begin.bracket.curly.java'
+            'patterns': [
+              {
+                'include': '#variables'
+              }
+              {
+                'include': '#code'
+              }
+            ]
+            'end': '(?=})'
+            'contentName': 'meta.finally.body.java'
+          }
+        ]
+        'end': '}'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.finally.end.bracket.curly.java'
+        'name': 'meta.finally.java'
       }
     ]
   'constants-and-special-vars':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -529,7 +529,7 @@
       }
       # catch block (with "parameters")
       {
-        'begin': '(\\bcatch\\b)\\s*(?=\\([^ ]+\\s*[^)]+\\))'
+        'begin': '\\b(catch)\\b\\s*(?=\\([^\\s]+\\s*[^)]+\\))'
         'beginCaptures':
           '1':
             'name': 'keyword.control.catch.java'
@@ -575,7 +575,7 @@
       }
       # finally block
       {
-        'begin': '(\\bfinally\\b)'
+        'begin': '\\b(finally)\\b'
         'beginCaptures':
           '1':
             'name': 'keyword.control.finally.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -529,7 +529,7 @@
       }
       # catch block (with "parameters")
       {
-        'begin': '\\b(catch)\\b\\s*(?=\\([^\\s]+\\s*[^)]+\\))'
+        'begin': '\\b(catch)\\b\\s*(?=\\(\\s*[^\\s]+\\s*[^)]+\\))'
         'beginCaptures':
           '1':
             'name': 'keyword.control.catch.java'
@@ -575,9 +575,9 @@
       }
       # finally block
       {
-        'begin': '\\b(finally)\\b'
+        'begin': '\\bfinally\\b'
         'beginCaptures':
-          '1':
+          '0':
             'name': 'keyword.control.finally.java'
         'end': '}'
         'endCaptures':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -555,6 +555,8 @@
             'beginCaptures':
               '0':
                 'name':'punctuation.section.catch.begin.bracket.curly.java'
+            'end': '(?=})'
+            'contentName': 'meta.catch.body.java'
             'patterns': [
               {
                 'include': '#variables'
@@ -563,8 +565,6 @@
                 'include': '#code'
               }
             ]
-            'end': '(?=})'
-            'contentName': 'meta.catch.body.java'
           }
         ]
       }

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -721,8 +721,8 @@
   'keywords':
     'patterns': [
       {
-        'match': '\\b(try|catch|finally|throw)\\b'
-        'name': 'keyword.control.catch-exception.java'
+        'match': '\\bthrow\\b'
+        'name': 'keyword.control.throw.java'
       }
       {
         'match': '\\?|:'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -486,3 +486,139 @@ describe 'Java grammar', ->
 
     expect(lines[8][5]).toEqual value: 'CAPITALVARIABLE', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.definition.java']
     expect(lines[8][6]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.terminator.java']
+
+  it 'tokenizes try-catch-finally blocks', ->
+    lines = grammar.tokenizeLines '''
+    class Test {
+      public void fn() {
+        try {
+          errorProneMethod();
+        } catch (RuntimeException re) {
+          handleRuntimeException(re);
+        } catch (Exception e) {
+          String variable = "assigning for some reason";
+        } finally {
+          // Relax, it's over
+          new Thingie().call();
+        }
+      }
+    }
+    '''
+
+    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ]
+
+    scopeStack.push 'meta.try.java'
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
+    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.try.body.java'
+    expect(lines[3][1]).toEqual value: 'errorProneMethod', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+
+    scopeStack.pop()
+    expect(lines[4][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    scopeStack.pop()
+    scopeStack.push 'meta.catch.java'
+    expect(lines[4][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
+    expect(lines[4][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    scopeStack.push 'meta.catch.parameters.java'
+    expect(lines[4][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat [ 'storage.type.java' ]
+    expect(lines[4][8]).toEqual value: 're', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    scopeStack.pop()
+    expect(lines[4][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
+    expect(lines[4][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.catch.body.java'
+    expect(lines[5][1]).toEqual value: 'handleRuntimeException', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+
+    scopeStack.pop()
+    expect(lines[6][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+    expect(lines[6][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
+    expect(lines[6][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    scopeStack.push 'meta.catch.parameters.java'
+    expect(lines[6][6]).toEqual value: 'Exception', scopes: scopeStack.concat [ 'storage.type.java' ]
+    expect(lines[6][8]).toEqual value: 'e', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    scopeStack.pop()
+    expect(lines[6][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
+    expect(lines[6][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.catch.body.java'
+    expect(lines[7][1]).toEqual value: 'String', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'storage.type.java' ]
+    expect(lines[7][3]).toEqual value: 'variable', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'variable.definition.java' ]
+
+    scopeStack.pop()
+    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+    scopeStack.pop()
+    scopeStack.push 'meta.finally.java'
+    expect(lines[8][3]).toEqual value: 'finally', scopes: scopeStack.concat [ 'keyword.control.finally.java' ]
+    expect(lines[8][5]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.finally.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.finally.body.java'
+    expect(lines[9][1]).toEqual value: '//', scopes: scopeStack.concat [ 'comment.line.double-slash.java', 'punctuation.definition.comment.java' ]
+
+    expect(lines[10][1]).toEqual value: 'new', scopes: scopeStack.concat [ 'keyword.control.new.java' ]
+
+    scopeStack.pop()
+    expect(lines[11][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.finally.end.bracket.curly.java' ]
+
+  it 'tokenizes nested try-catch-finally blocks', ->
+    lines = grammar.tokenizeLines '''
+    class Test {
+      public void fn() {
+        try {
+          try {
+            String nested;
+          } catch (Exception e) {
+            handleNestedException();
+          }
+        } catch (RuntimeException re) {}
+      }
+    }
+    '''
+
+    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ];
+
+    scopeStack.push 'meta.try.java'
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
+    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.try.body.java', 'meta.try.java'
+    expect(lines[3][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
+    expect(lines[3][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.try.body.java'
+    expect(lines[4][1]).toEqual value: 'String', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'storage.type.java' ]
+    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'variable.definition.java' ]
+
+    scopeStack.pop()
+    expect(lines[5][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    scopeStack.pop()
+    scopeStack.push 'meta.catch.java'
+    expect(lines[5][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
+    expect(lines[5][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    scopeStack.push 'meta.catch.parameters.java'
+    expect(lines[5][6]).toEqual value: 'Exception', scopes: scopeStack.concat ['storage.type.java' ]
+    expect(lines[5][8]).toEqual value: 'e', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    scopeStack.pop()
+    expect(lines[5][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
+    expect(lines[5][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+
+    scopeStack.push 'meta.catch.body.java'
+    expect(lines[6][1]).toEqual value: 'handleNestedException', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+
+    scopeStack.pop()
+    expect(lines[7][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+
+    scopeStack.pop()
+    scopeStack.pop()
+    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    scopeStack.pop()
+    scopeStack.push 'meta.catch.java'
+    expect(lines[8][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
+    expect(lines[8][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    scopeStack.push 'meta.catch.parameters.java'
+    expect(lines[8][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat ['storage.type.java' ]
+    expect(lines[8][8]).toEqual value: 're', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    scopeStack.pop()
+    expect(lines[8][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
+    expect(lines[8][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+    expect(lines[8][12]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -575,50 +575,60 @@ describe 'Java grammar', ->
     }
     '''
 
-    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ]
+    scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
 
     scopeStack.push 'meta.try.java'
-    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
-    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat ['keyword.control.try.java']
+    expect(lines[2][2]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.try.begin.bracket.curly.java']
 
     scopeStack.push 'meta.try.body.java', 'meta.try.java'
-    expect(lines[3][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
-    expect(lines[3][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+    expect(lines[3][1]).toEqual value: 'try', scopes: scopeStack.concat ['keyword.control.try.java']
+    expect(lines[3][2]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[3][3]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.try.begin.bracket.curly.java']
 
     scopeStack.push 'meta.try.body.java'
-    expect(lines[4][1]).toEqual value: 'String', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'storage.type.java' ]
-    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'variable.definition.java' ]
+    expect(lines[4][1]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
+    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.definition.java']
 
     scopeStack.pop()
-    expect(lines[5][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    expect(lines[5][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.try.end.bracket.curly.java']
     scopeStack.pop()
+    expect(lines[5][2]).toEqual value: ' ', scopes: scopeStack
     scopeStack.push 'meta.catch.java'
-    expect(lines[5][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
-    expect(lines[5][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    expect(lines[5][3]).toEqual value: 'catch', scopes: scopeStack.concat ['keyword.control.catch.java']
+    expect(lines[5][4]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[5][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java' ]
     scopeStack.push 'meta.catch.parameters.java'
-    expect(lines[5][6]).toEqual value: 'Exception', scopes: scopeStack.concat ['storage.type.java' ]
-    expect(lines[5][8]).toEqual value: 'e', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    expect(lines[5][6]).toEqual value: 'Exception', scopes: scopeStack.concat ['storage.type.java']
+    expect(lines[5][7]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[5][8]).toEqual value: 'e', scopes: scopeStack.concat ['variable.parameter.java']
     scopeStack.pop()
-    expect(lines[5][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
-    expect(lines[5][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+    expect(lines[5][9]).toEqual value: ')', scopes: scopeStack.concat ['punctuation.definition.parameters.end.bracket.round.java']
+    expect(lines[5][10]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[5][11]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.catch.begin.bracket.curly.java']
 
     scopeStack.push 'meta.catch.body.java'
-    expect(lines[6][1]).toEqual value: 'handleNestedException', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+    expect(lines[6][1]).toEqual value: 'handleNestedException', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
 
     scopeStack.pop()
-    expect(lines[7][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+    expect(lines[7][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']
 
     scopeStack.pop()
     scopeStack.pop()
-    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.try.end.bracket.curly.java']
     scopeStack.pop()
+    expect(lines[8][2]).toEqual value: ' ', scopes: scopeStack
     scopeStack.push 'meta.catch.java'
-    expect(lines[8][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
-    expect(lines[8][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    expect(lines[8][3]).toEqual value: 'catch', scopes: scopeStack.concat ['keyword.control.catch.java']
+    expect(lines[8][4]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[8][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java']
     scopeStack.push 'meta.catch.parameters.java'
     expect(lines[8][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat ['storage.type.java' ]
-    expect(lines[8][8]).toEqual value: 're', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    expect(lines[8][7]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[8][8]).toEqual value: 're', scopes: scopeStack.concat ['variable.parameter.java']
     scopeStack.pop()
-    expect(lines[8][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
-    expect(lines[8][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
-    expect(lines[8][12]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+    expect(lines[8][9]).toEqual value: ')', scopes: scopeStack.concat ['punctuation.definition.parameters.end.bracket.round.java']
+    expect(lines[8][10]).toEqual value: ' ', scopes: scopeStack
+    expect(lines[8][11]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.catch.begin.bracket.curly.java']
+    expect(lines[8][12]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -506,60 +506,60 @@ describe 'Java grammar', ->
     }
     '''
 
-    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ]
+    scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
 
     scopeStack.push 'meta.try.java'
-    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]
-    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.try.begin.bracket.curly.java' ]
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat ['keyword.control.try.java']
+    expect(lines[2][3]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.try.begin.bracket.curly.java']
 
     scopeStack.push 'meta.try.body.java'
-    expect(lines[3][1]).toEqual value: 'errorProneMethod', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+    expect(lines[3][1]).toEqual value: 'errorProneMethod', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
 
     scopeStack.pop()
-    expect(lines[4][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.try.end.bracket.curly.java' ]
+    expect(lines[4][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.try.end.bracket.curly.java']
     scopeStack.pop()
     scopeStack.push 'meta.catch.java'
-    expect(lines[4][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
-    expect(lines[4][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    expect(lines[4][3]).toEqual value: 'catch', scopes: scopeStack.concat ['keyword.control.catch.java']
+    expect(lines[4][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java']
     scopeStack.push 'meta.catch.parameters.java'
-    expect(lines[4][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat [ 'storage.type.java' ]
-    expect(lines[4][8]).toEqual value: 're', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    expect(lines[4][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat ['storage.type.java']
+    expect(lines[4][8]).toEqual value: 're', scopes: scopeStack.concat ['variable.parameter.java']
     scopeStack.pop()
-    expect(lines[4][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
-    expect(lines[4][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+    expect(lines[4][9]).toEqual value: ')', scopes: scopeStack.concat ['punctuation.definition.parameters.end.bracket.round.java']
+    expect(lines[4][11]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.catch.begin.bracket.curly.java']
 
     scopeStack.push 'meta.catch.body.java'
-    expect(lines[5][1]).toEqual value: 'handleRuntimeException', scopes: scopeStack.concat [ 'meta.function-call.java', 'entity.name.function.java' ]
+    expect(lines[5][1]).toEqual value: 'handleRuntimeException', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
 
     scopeStack.pop()
-    expect(lines[6][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
-    expect(lines[6][3]).toEqual value: 'catch', scopes: scopeStack.concat [ 'keyword.control.catch.java' ]
-    expect(lines[6][5]).toEqual value: '(', scopes: scopeStack.concat [ 'punctuation.definition.parameters.begin.bracket.round.java' ]
+    expect(lines[6][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']
+    expect(lines[6][3]).toEqual value: 'catch', scopes: scopeStack.concat ['keyword.control.catch.java']
+    expect(lines[6][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java']
     scopeStack.push 'meta.catch.parameters.java'
-    expect(lines[6][6]).toEqual value: 'Exception', scopes: scopeStack.concat [ 'storage.type.java' ]
-    expect(lines[6][8]).toEqual value: 'e', scopes: scopeStack.concat [ 'variable.parameter.java' ]
+    expect(lines[6][6]).toEqual value: 'Exception', scopes: scopeStack.concat ['storage.type.java']
+    expect(lines[6][8]).toEqual value: 'e', scopes: scopeStack.concat ['variable.parameter.java']
     scopeStack.pop()
-    expect(lines[6][9]).toEqual value: ')', scopes: scopeStack.concat [ 'punctuation.definition.parameters.end.bracket.round.java' ]
-    expect(lines[6][11]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.catch.begin.bracket.curly.java' ]
+    expect(lines[6][9]).toEqual value: ')', scopes: scopeStack.concat ['punctuation.definition.parameters.end.bracket.round.java']
+    expect(lines[6][11]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.catch.begin.bracket.curly.java']
 
     scopeStack.push 'meta.catch.body.java'
-    expect(lines[7][1]).toEqual value: 'String', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'storage.type.java' ]
-    expect(lines[7][3]).toEqual value: 'variable', scopes: scopeStack.concat [ 'meta.definition.variable.java', 'variable.definition.java' ]
+    expect(lines[7][1]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
+    expect(lines[7][3]).toEqual value: 'variable', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
 
     scopeStack.pop()
-    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.catch.end.bracket.curly.java' ]
+    expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']
     scopeStack.pop()
     scopeStack.push 'meta.finally.java'
-    expect(lines[8][3]).toEqual value: 'finally', scopes: scopeStack.concat [ 'keyword.control.finally.java' ]
-    expect(lines[8][5]).toEqual value: '{', scopes: scopeStack.concat [ 'punctuation.section.finally.begin.bracket.curly.java' ]
+    expect(lines[8][3]).toEqual value: 'finally', scopes: scopeStack.concat ['keyword.control.finally.java']
+    expect(lines[8][5]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.finally.begin.bracket.curly.java']
 
     scopeStack.push 'meta.finally.body.java'
-    expect(lines[9][1]).toEqual value: '//', scopes: scopeStack.concat [ 'comment.line.double-slash.java', 'punctuation.definition.comment.java' ]
+    expect(lines[9][1]).toEqual value: '//', scopes: scopeStack.concat ['comment.line.double-slash.java', 'punctuation.definition.comment.java']
 
-    expect(lines[10][1]).toEqual value: 'new', scopes: scopeStack.concat [ 'keyword.control.new.java' ]
+    expect(lines[10][1]).toEqual value: 'new', scopes: scopeStack.concat ['keyword.control.new.java']
 
     scopeStack.pop()
-    expect(lines[11][1]).toEqual value: '}', scopes: scopeStack.concat [ 'punctuation.section.finally.end.bracket.curly.java' ]
+    expect(lines[11][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.finally.end.bracket.curly.java']
 
   it 'tokenizes nested try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
@@ -590,7 +590,7 @@ describe 'Java grammar', ->
 
     scopeStack.push 'meta.try.body.java'
     expect(lines[4][1]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
-    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.definition.java']
+    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
 
     scopeStack.pop()
     expect(lines[5][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.try.end.bracket.curly.java']
@@ -599,7 +599,7 @@ describe 'Java grammar', ->
     scopeStack.push 'meta.catch.java'
     expect(lines[5][3]).toEqual value: 'catch', scopes: scopeStack.concat ['keyword.control.catch.java']
     expect(lines[5][4]).toEqual value: ' ', scopes: scopeStack
-    expect(lines[5][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java' ]
+    expect(lines[5][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java']
     scopeStack.push 'meta.catch.parameters.java'
     expect(lines[5][6]).toEqual value: 'Exception', scopes: scopeStack.concat ['storage.type.java']
     expect(lines[5][7]).toEqual value: ' ', scopes: scopeStack
@@ -625,7 +625,7 @@ describe 'Java grammar', ->
     expect(lines[8][4]).toEqual value: ' ', scopes: scopeStack
     expect(lines[8][5]).toEqual value: '(', scopes: scopeStack.concat ['punctuation.definition.parameters.begin.bracket.round.java']
     scopeStack.push 'meta.catch.parameters.java'
-    expect(lines[8][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat ['storage.type.java' ]
+    expect(lines[8][6]).toEqual value: 'RuntimeException', scopes: scopeStack.concat ['storage.type.java']
     expect(lines[8][7]).toEqual value: ' ', scopes: scopeStack
     expect(lines[8][8]).toEqual value: 're', scopes: scopeStack.concat ['variable.parameter.java']
     scopeStack.pop()

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -575,7 +575,7 @@ describe 'Java grammar', ->
     }
     '''
 
-    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ];
+    scopeStack = [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java' ]
 
     scopeStack.push 'meta.try.java'
     expect(lines[2][1]).toEqual value: 'try', scopes: scopeStack.concat [ 'keyword.control.try.java' ]


### PR DESCRIPTION
This adds scopes to try-catch-finally blocks:

  * Curly braces `punctuation.section.(try|catch|finally).(begin|end).bracket.curly.java`
  * Bodies within curly braces `meta.(try|catch|finally).body.java`
  * Parameters to exception get `meta.catch.parameters.java` so it can be distinguished from method parameters

Additional bonus: variables are correctly scoped within try, catch or finally blocks.

I've tried and follow the naming conventions of the scopes. If you feel they should be different, let me know.

Fixes #48