### PR TITLE
Add javadoc comments

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -507,7 +507,6 @@
         '0':
           'name': 'punctuation.definition.comment.java'
       'name': 'comment.block.javadoc.java'
-      'contentName': 'meta.comment.block.javadoc.java'
       'patterns': [
         {
           'match': '@(author|deprecated|return|see|serial|since|version)\\b'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -462,6 +462,46 @@
   'comments-inline':
     'patterns': [
       {
+        'begin': '^\\s*/\\*\\*'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.java'
+        'end': '\\*/'
+        'name': 'comment.block.java'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'keyword.other.documentation.javadoc.java'
+              '2':
+                'name': 'variable.parameter.java'
+            'match': '(@param)\\s+(\\S+)'
+          }
+          {
+            'captures':
+              '1':
+                'name': 'keyword.other.documentation.javadoc.java'
+              '2':
+                'name': 'entity.name.type.class.java'
+            'match': '(@(?:exception|throws))\\s+(\\S+)'
+          }
+          {
+            'captures':
+              '1':
+                'name': 'keyword.other.documentation.javadoc.java'
+              '2':
+                'name': 'entity.name.type.class.java'
+              '3':
+                'name': 'variable.parameter.java'
+            'match': '\\{(@link)\\s+(\\S+)?#([^\\{\\}]+)\\}'
+          }
+          {
+            'match': '@(author|deprecated|exception|return|see|serial|since|throws|version)\\b'
+            'name': 'keyword.other.documentation.javadoc.java'
+          }
+        ]
+      }
+      {
         'begin': '/\\*'
         'captures':
           '0':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -493,7 +493,7 @@
                 'name': 'entity.name.type.class.java'
               '3':
                 'name': 'variable.parameter.java'
-            'match': '\\{(@link)\\s+(\\S+)?#([^\\{\\}]+)\\}'
+            'match': '\\{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]+\\)).*\\}'
           }
           {
             'match': '@(author|deprecated|exception|return|see|serial|since|throws|version)\\b'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -534,7 +534,7 @@
               'name': 'entity.name.type.class.java'
         }
         {
-          'match': '\\{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*\\}'
+          'match': '{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}'
           'captures':
             '1':
               'name': 'keyword.other.documentation.javadoc.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -100,6 +100,9 @@
     ]
   }
   {
+    'include': '#comments-javadoc'
+  }
+  {
     'include': '#code'
   }
 ]
@@ -335,6 +338,9 @@
   'class-body':
     'patterns': [
       {
+        'include': '#comments-javadoc'
+      }
+      {
         'include': '#comments'
       }
       {
@@ -465,46 +471,6 @@
   'comments-inline':
     'patterns': [
       {
-        'begin': '^\\s*/\\*\\*'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.java'
-        'end': '\\*/'
-        'name': 'comment.block.java'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'keyword.other.documentation.javadoc.java'
-              '2':
-                'name': 'variable.parameter.java'
-            'match': '(@param)\\s+(\\S+)'
-          }
-          {
-            'captures':
-              '1':
-                'name': 'keyword.other.documentation.javadoc.java'
-              '2':
-                'name': 'entity.name.type.class.java'
-            'match': '(@(?:exception|throws))\\s+(\\S+)'
-          }
-          {
-            'captures':
-              '1':
-                'name': 'keyword.other.documentation.javadoc.java'
-              '2':
-                'name': 'entity.name.type.class.java'
-              '3':
-                'name': 'variable.parameter.java'
-            'match': '\\{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]+\\)).*\\}'
-          }
-          {
-            'match': '@(author|deprecated|exception|return|see|serial|since|throws|version)\\b'
-            'name': 'keyword.other.documentation.javadoc.java'
-          }
-        ]
-      }
-      {
         'begin': '/\\*'
         'captures':
           '0':
@@ -529,6 +495,51 @@
           }
         ]
       }
+    ]
+  'comments-javadoc':
+    'patterns': [
+      'begin': '^\\s*/\\*\\*'
+      'beginCaptures':
+        '0':
+          'name': 'punctuation.definition.comment.java'
+      'end': '\\*/'
+      'endCaptures':
+        '0':
+          'name': 'punctuation.definition.comment.java'
+      'name': 'comment.block.javadoc.java'
+      'contentName': 'meta.comment.block.javadoc.java'
+      'patterns': [
+        {
+          'match': '@(author|deprecated|return|see|serial|since|version)\\b'
+          'name': 'keyword.other.documentation.javadoc.java'
+        }
+        {
+          'match': '(@param)\\s+(\\S+)'
+          'captures':
+            '1':
+              'name': 'keyword.other.documentation.javadoc.java'
+            '2':
+              'name': 'variable.parameter.java'
+        }
+        {
+          'match': '(@(?:exception|throws))\\s+(\\S+)'
+          'captures':
+            '1':
+              'name': 'keyword.other.documentation.javadoc.java'
+            '2':
+              'name': 'entity.name.type.class.java'
+        }
+        {
+          'match': '\\{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*\\}'
+          'captures':
+            '1':
+              'name': 'keyword.other.documentation.javadoc.java'
+            '2':
+              'name': 'entity.name.type.class.java'
+            '3':
+              'name': 'variable.parameter.java'
+        }
+      ]
     ]
   'try-catch-finally':
     'patterns': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-java",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Java language support in Atom",
   "engines": {
     "atom": "*",

--- a/settings/language-java.cson
+++ b/settings/language-java.cson
@@ -17,3 +17,18 @@
 '.source.java-properties':
   'editor':
     'commentStart': '# '
+'.keyword.other.documentation.javadoc.java':
+  'editor':
+    'completions': [
+      'author'
+      'deprecated'
+      'exception'
+      'link'
+      'param'
+      'return'
+      'see'
+      'serial'
+      'since'
+      'throws'
+      'version'
+    ]

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -537,7 +537,7 @@ describe 'Java grammar', ->
     expect(lines[6][1]).toEqual value: '*/', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
 
     expect(lines[9][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'punctuation.definition.comment.java']
-    expect(lines[9][1]).toEqual value : ' ', scopes : ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[9][1]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
     expect(lines[9][2]).toEqual value: '@serial', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
     expect(lines[9][3]).toEqual value: ' reference ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
     expect(lines[9][4]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'punctuation.definition.comment.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -587,7 +587,9 @@ describe 'Java grammar', ->
         /**
          * Use {@link #method(int a)}
          * Use {@link Class#method(int a)}
+         * Use {@link Class#method (int a, int b)}
          * @link #method()
+         * Use {@link Class#method$(int a) label {@link Class#method()}}
          */
         public int test() { return -1; }
       }
@@ -607,4 +609,16 @@ describe 'Java grammar', ->
     expect(lines[4][6]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
     expect(lines[4][7]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
 
-    expect(lines[5][0]).toEqual value: '   * @link #method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[5][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'entity.name.type.class.java']
+    expect(lines[5][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[5][6]).toEqual value: 'method (int a, int b)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
+
+    expect(lines[6][0]).toEqual value: '   * @link #method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+    expect(lines[7][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[7][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[7][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[7][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'entity.name.type.class.java']
+    expect(lines[7][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[7][6]).toEqual value: 'method$(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
+    expect(lines[7][7]).toEqual value: ' label {@link Class#method()}}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -639,7 +639,7 @@ describe 'Java grammar', ->
       class Test
       {
         private void method() {
-          /** sort of javadoc comment */
+          /** invalid javadoc comment */
           /* inline comment */
           // single-line comment
         }
@@ -647,7 +647,7 @@ describe 'Java grammar', ->
       '''
 
     expect(lines[3][1]).toEqual value: '/*', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.block.java', 'punctuation.definition.comment.java']
-    expect(lines[3][2]).toEqual value: '* sort of javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.block.java']
+    expect(lines[3][2]).toEqual value: '* invalid javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.block.java']
     expect(lines[3][3]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.block.java', 'punctuation.definition.comment.java']
 
     expect(lines[4][1]).toEqual value: '/*', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.block.java', 'punctuation.definition.comment.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -666,7 +666,7 @@ describe 'Java grammar', ->
       '''
 
     expect(lines[0][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
-    expect(lines[0][1]).toEqual value: ' single-line javadoc comment ', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[0][1]).toEqual value: ' single-line javadoc comment ', scopes: ['source.java', 'comment.block.javadoc.java']
     expect(lines[0][2]).toEqual value: '*/', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
   it 'tokenizes javadoc comment inside class body', ->
@@ -682,11 +682,11 @@ describe 'Java grammar', ->
       '''
 
     expect(lines[1][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
-    expect(lines[1][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[1][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java']
     expect(lines[1][2]).toEqual value: '*/', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
     expect(lines[5][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
-    expect(lines[5][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[5][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
     expect(lines[5][2]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
   it 'tokenizes multi-line basic javadoc comment', ->
@@ -703,22 +703,22 @@ describe 'Java grammar', ->
 
     expect(lines[0][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
-    expect(lines[1][1]).toEqual value: '@author', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[1][2]).toEqual value: ' John Smith', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[1][1]).toEqual value: '@author', scopes: ['source.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[1][2]).toEqual value: ' John Smith', scopes: ['source.java', 'comment.block.javadoc.java']
 
-    expect(lines[2][1]).toEqual value: '@deprecated', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[2][2]).toEqual value: ' description', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[2][1]).toEqual value: '@deprecated', scopes: ['source.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[2][2]).toEqual value: ' description', scopes: ['source.java', 'comment.block.javadoc.java']
 
-    expect(lines[3][1]).toEqual value: '@see', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[3][2]).toEqual value: ' reference', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[3][1]).toEqual value: '@see', scopes: ['source.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][2]).toEqual value: ' reference', scopes: ['source.java', 'comment.block.javadoc.java']
 
-    expect(lines[4][1]).toEqual value: '@since', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[4][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[4][1]).toEqual value: '@since', scopes: ['source.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.javadoc.java']
 
-    expect(lines[5][1]).toEqual value: '@version', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[5][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[5][1]).toEqual value: '@version', scopes: ['source.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[5][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.javadoc.java']
 
-    expect(lines[6][0]).toEqual value: ' ', scopes: ['source.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[6][0]).toEqual value: ' ', scopes: ['source.java', 'comment.block.javadoc.java']
     expect(lines[6][1]).toEqual value: '*/', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
   it 'tokenizes `param` javadoc comment', ->
@@ -735,9 +735,9 @@ describe 'Java grammar', ->
       }
       '''
 
-    expect(lines[4][1]).toEqual value: '@param', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[4][3]).toEqual value: 'num', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
-    expect(lines[4][4]).toEqual value: ' value to increment.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[4][1]).toEqual value: '@param', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: 'num', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[4][4]).toEqual value: ' value to increment.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
 
   it 'tokenizes `exception`/`throws` javadoc comment', ->
     lines = grammar.tokenizeLines '''
@@ -751,13 +751,13 @@ describe 'Java grammar', ->
       }
       '''
 
-    expect(lines[3][1]).toEqual value: '@throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[3][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'entity.name.type.class.java']
-    expect(lines[3][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[3][1]).toEqual value: '@throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
+    expect(lines[3][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
 
-    expect(lines[4][1]).toEqual value: '@exception', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[4][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'entity.name.type.class.java']
-    expect(lines[4][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[4][1]).toEqual value: '@exception', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
+    expect(lines[4][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
 
   it 'tokenizes `link` javadoc comment', ->
     lines = grammar.tokenizeLines '''
@@ -775,29 +775,29 @@ describe 'Java grammar', ->
       }
       '''
 
-    expect(lines[3][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[3][3]).toEqual value: ' #', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[3][4]).toEqual value: 'method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[3][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][3]).toEqual value: ' #', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[3][4]).toEqual value: 'method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
 
-    expect(lines[4][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[4][3]).toEqual value: ' #', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[4][4]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[4][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: ' #', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[4][4]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
 
-    expect(lines[5][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[5][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[5][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'entity.name.type.class.java']
-    expect(lines[5][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[5][6]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[5][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[5][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[5][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
+    expect(lines[5][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[5][6]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
 
-    expect(lines[6][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'entity.name.type.class.java']
-    expect(lines[6][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[6][6]).toEqual value: 'method (int a, int b)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[6][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
+    expect(lines[6][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[6][6]).toEqual value: 'method (int a, int b)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
 
-    expect(lines[7][0]).toEqual value: '   * @link #method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[7][0]).toEqual value: '   * @link #method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
 
-    expect(lines[8][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
-    expect(lines[8][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[8][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'entity.name.type.class.java']
-    expect(lines[8][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
-    expect(lines[8][6]).toEqual value: 'method$(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java', 'variable.parameter.java']
-    expect(lines[8][7]).toEqual value: ' label {@link Class#method()}}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'meta.comment.block.javadoc.java']
+    expect(lines[8][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[8][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[8][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
+    expect(lines[8][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[8][6]).toEqual value: 'method$(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
+    expect(lines[8][7]).toEqual value: ' label {@link Class#method()}}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -196,7 +196,7 @@ describe 'Java grammar', ->
   it 'tokenizes enums', ->
     lines = grammar.tokenizeLines '''
       enum Letters {
-        /** Comment about A */
+        /* Comment about A */
         A,
 
         // Comment about B
@@ -211,7 +211,7 @@ describe 'Java grammar', ->
     expect(lines[0][2]).toEqual value: 'Letters', scopes: ['source.java', 'meta.enum.java', 'entity.name.type.enum.java']
     expect(lines[0][4]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.begin.bracket.curly.java']
     expect(lines[1][1]).toEqual value: '/*', scopes: commentDefinition
-    expect(lines[1][2]).toEqual value: '* Comment about A ', scopes: comment
+    expect(lines[1][2]).toEqual value: ' Comment about A ', scopes: comment
     expect(lines[1][3]).toEqual value: '*/', scopes: commentDefinition
     expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
     expect(lines[6][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
@@ -486,3 +486,125 @@ describe 'Java grammar', ->
 
     expect(lines[8][5]).toEqual value: 'CAPITALVARIABLE', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.definition.java']
     expect(lines[8][6]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.terminator.java']
+
+  it 'tokenizes single-line javadoc comment', ->
+    lines = grammar.tokenizeLines '''
+      /** [[Test]] interface for single-line comment */
+      class Test
+      {
+        private int variable;
+      }
+      '''
+
+    expect(lines[0][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+    expect(lines[0][1]).toEqual value: ' [[Test]] interface for single-line comment ', scopes: ['source.java', 'comment.block.java']
+    expect(lines[0][2]).toEqual value: '*/', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+
+  it 'tokenizes multi-line basic javadoc comment', ->
+    lines = grammar.tokenizeLines '''
+      /**
+       * @author John Smith
+       * @deprecated description
+       * @see reference
+       * @since version
+       * @version version
+       */
+      class Test
+      {
+        /** @serial reference */
+        private int variable;
+      }
+      '''
+
+    expect(lines[0][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+
+    expect(lines[1][1]).toEqual value: '@author', scopes: ['source.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[1][2]).toEqual value: ' John Smith', scopes: ['source.java', 'comment.block.java']
+
+    expect(lines[2][1]).toEqual value: '@deprecated', scopes: ['source.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[2][2]).toEqual value: ' description', scopes: ['source.java', 'comment.block.java']
+
+    expect(lines[3][1]).toEqual value: '@see', scopes: ['source.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][2]).toEqual value: ' reference', scopes: ['source.java', 'comment.block.java']
+
+    expect(lines[4][1]).toEqual value: '@since', scopes: ['source.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.java']
+
+    expect(lines[5][1]).toEqual value: '@version', scopes: ['source.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[5][2]).toEqual value: ' version', scopes: ['source.java', 'comment.block.java']
+
+    expect(lines[6][0]).toEqual value: ' ', scopes: ['source.java', 'comment.block.java']
+    expect(lines[6][1]).toEqual value: '*/', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+
+    expect(lines[9][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'punctuation.definition.comment.java']
+    expect(lines[9][1]).toEqual value : ' ', scopes : ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[9][2]).toEqual value: '@serial', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[9][3]).toEqual value: ' reference ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[9][4]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'punctuation.definition.comment.java']
+
+  it 'tokenizes `param` javadoc comment', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        /**
+         * Increment number.
+         * @param num value to increment.
+         */
+        public void inc(int num) {
+          num += 1;
+        }
+      }
+      '''
+
+    expect(lines[4][1]).toEqual value: '@param', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: 'num', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
+    expect(lines[4][4]).toEqual value: ' value to increment.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+  it 'tokenizes `exception`/`throws` javadoc comment', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        /**
+         * @throws IllegalStateException reason
+         * @exception IllegalStateException reason
+         */
+        public void fail() { throw new IllegalStateException(); }
+      }
+      '''
+
+    expect(lines[3][1]).toEqual value: '@throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'entity.name.type.class.java']
+    expect(lines[3][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+    expect(lines[4][1]).toEqual value: '@exception', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: 'IllegalStateException', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'entity.name.type.class.java']
+    expect(lines[4][4]).toEqual value: ' reason', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+  it 'tokenizes `link` javadoc comment', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        /**
+         * Use {@link #method(int a)}
+         * Use {@link Class#method(int a)}
+         * @link #method()
+         */
+        public int test() { return -1; }
+      }
+      '''
+
+    expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[3][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[3][3]).toEqual value: ' #', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[3][4]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
+    expect(lines[3][5]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+    expect(lines[4][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[4][2]).toEqual value: '@link', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'keyword.other.documentation.javadoc.java']
+    expect(lines[4][3]).toEqual value: ' ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[4][4]).toEqual value: 'Class', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'entity.name.type.class.java']
+    expect(lines[4][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+    expect(lines[4][6]).toEqual value: 'method(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java', 'variable.parameter.java']
+    expect(lines[4][7]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']
+
+    expect(lines[5][0]).toEqual value: '   * @link #method()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.java']


### PR DESCRIPTION
This PR adds javadoc comments to `language-java`: `@author`, `@deprecated`, `@exception`, `@return`, `@see`, `@serial`, `@since`, `@throws`, `@version`, `@param`, and `@link`, mentioned in issue #54. I tried adding highlighting for embedded code snippet in javadoc comments, but could not make it work.

Used [language-scala](https://github.com/atom-community/language-scala) package mainly for guidance and implementation, since Atom packages are new to me.

Here is what it looks like in Atom:
![sample](https://cloud.githubusercontent.com/assets/7788766/15989121/b51e4090-30c0-11e6-83d6-12fb59128b17.png)

#### Testing
Updated existing `tokenizes enum` test, added unit-tests.


