### PR TITLE
Fix test failures

### DIFF
--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -543,7 +543,7 @@ describe 'Java grammar', ->
 
     scopeStack.push 'meta.catch.body.java'
     expect(lines[7][1]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
-    expect(lines[7][3]).toEqual value: 'variable', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[7][3]).toEqual value: 'variable', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.definition.java']
 
     scopeStack.pop()
     expect(lines[8][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']
@@ -589,7 +589,7 @@ describe 'Java grammar', ->
 
     scopeStack.push 'meta.try.body.java'
     expect(lines[4][1]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
-    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[4][3]).toEqual value: 'nested', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.definition.java']
 
     scopeStack.pop()
     expect(lines[5][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.try.end.bracket.curly.java']


### PR DESCRIPTION
It seems like master branch tests are broken:
```
[751:0613/174256:INFO:CONSOLE(52)] "Window load time: 503ms", source: file:///Applications/Atom.app/Contents/Resources/app.asar/static/index.js (52)
................FF

Java grammar
  it tokenizes try-catch-finally blocks
    Expected { value : 'variable', scopes : [ 'source.java', 'meta.class.java', 'meta.class.body.java', 
      'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.body.java', 
      'meta.definition.variable.java', 'variable.definition.java' ] 
    } to equal { value : 'variable', scopes : [ 'source.java', 'meta.class.java', 'meta.class.body.java', 
      'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.body.java', 
      'meta.definition.variable.java', 'variable.other.definition.java' ] }. (../../language-java/spec/java-spec.coffee:546:25)
  it tokenizes nested try-catch-finally blocks
    Expected { value : 'nested', scopes : [ 'source.java', 'meta.class.java', 'meta.class.body.java', 
      'meta.method.java', 'meta.method.body.java', 'meta.try.java', 'meta.try.body.java', 'meta.try.java', 
      'meta.try.body.java', 'meta.definition.variable.java', 'variable.definition.java' ] 
    } to equal { value : 'nested', scopes : [ 'source.java', 'meta.class.java', 'meta.class.body.java', 
      'meta.method.java', 'meta.method.body.java', 'meta.try.java', 'meta.try.body.java', 'meta.try.java', 
      'meta.try.body.java', 'meta.definition.variable.java', 'variable.other.definition.java' ] }. (../../language-java/spec/java-spec.coffee:592:25)


Finished in 0.58 seconds
18 tests, 291 assertions, 2 failures, 0 skipped

Tests failed
```

This PR fixes this by changing `variable.other.definition.java` to `variable.definition.java`.