### PR TITLE
Require storage type and identifier

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1123,7 +1123,7 @@
         ([\\w<>\\[\\],][\\w<>\\[\\],?\\s]*)?
         \\s+
         [A-Za-z_$][\\w$]* # At least one identifier after space
-        ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly more generic, primite arrays etc.
+        ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers
         \\s*(=|;)
       ))
     '''

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1122,7 +1122,7 @@
         )
         ([\\w\\d<>\\[\\],][\\w\\d<>\\[\\],?\\s]*)?
         \\s+
-        [\\w\\d$]+ # At least one identifier after space
+        [A-Za-z_$][\\w\\d$]* # At least one identifier after space
         ([\\w\\d\\[\\],$][\\w\\d\\[\\],\\s]*)?
         \\s*(=|;)
       ))
@@ -1131,7 +1131,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([\\w\\d$]{1,})(?=\\s*(\\[\\])*\\s*(;|=|,))'
+        'match': '([A-Za-z_$][\\w\\d$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
         'captures':
           '1':
             'name': 'variable.other.definition.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1120,10 +1120,10 @@
           |
           ((\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
-        ([\\w\\d<>\\[\\],][\\w\\d<>\\[\\],?\\s]*)?
+        ([\\w<>\\[\\],][\\w<>\\[\\],?\\s]*)?
         \\s+
-        [A-Za-z_$][\\w\\d$]* # At least one identifier after space
-        ([\\w\\d\\[\\],$][\\w\\d\\[\\],\\s]*)?
+        [A-Za-z_$][\\w$]* # At least one identifier after space
+        ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly more generic, primite arrays etc.
         \\s*(=|;)
       ))
     '''
@@ -1131,7 +1131,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([A-Za-z_$][\\w\\d$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
+        'match': '([A-Za-z_$][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
         'captures':
           '1':
             'name': 'variable.other.definition.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1131,7 +1131,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([A-Za-z_$][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
+        'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
         'captures':
           '1':
             'name': 'variable.other.definition.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1120,9 +1120,10 @@
           |
           ((\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
-        ([\\w\\d<>\\[\\],?][\\w\\d_<>\\[\\],?\\s]*)?
+        ([\\w\\d<>\\[\\],][\\w\\d<>\\[\\],?\\s]*)?
         \\s+
-        [\\w\\d<>\\[\\],?][\\w\\d_<>\\[\\],?\\s]*
+        [\\w\\d$]+ # At least one identifier after space
+        ([\\w\\d\\[\\],$][\\w\\d\\[\\],\\s]*)?
         \\s*(=|;)
       ))
     '''
@@ -1130,7 +1131,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
+        'match': '([\\w\\d$]{1,})(?=\\s*(\\[\\])*\\s*(;|=|,))'
         'captures':
           '1':
             'name': 'variable.other.definition.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -446,6 +446,11 @@ describe 'Java grammar', ->
         private int variable1, variable2 = variable;
         private int variable;// = 3;
         public String CAPITALVARIABLE;
+        private int[][] somevar = new int[10][12];
+        private int 1invalid;
+        private Integer $tar_war$;
+        double a,b,c;double d;
+        String[] primitiveArray;
       }
       '''
 
@@ -487,6 +492,41 @@ describe 'Java grammar', ->
 
     expect(lines[8][5]).toEqual value: 'CAPITALVARIABLE', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
     expect(lines[8][6]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.terminator.java']
+
+    expect(lines[9][3]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.array.java']
+    expect(lines[9][4]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
+    expect(lines[9][5]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
+    expect(lines[9][6]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
+    expect(lines[9][7]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.array.java', 'punctuation.bracket.square.java']
+    expect(lines[9][9]).toEqual value: 'somevar', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[9][15]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[9][16]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[9][17]).toEqual value: '10', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'constant.numeric.java']
+    expect(lines[9][18]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[9][19]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[9][20]).toEqual value: '12', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'constant.numeric.java']
+    expect(lines[9][21]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+
+    expect(lines[10][2]).toEqual value: ' int 1invalid', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
+
+    expect(lines[11][3]).toEqual value: 'Integer', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[11][5]).toEqual value: '$tar_war$', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+
+    expect(lines[12][1]).toEqual value: 'double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[12][3]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[12][4]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.delimiter.java']
+    expect(lines[12][5]).toEqual value: 'b', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[12][6]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.delimiter.java']
+    expect(lines[12][7]).toEqual value: 'c', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[12][8]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.terminator.java']
+    expect(lines[12][9]).toEqual value: 'double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[12][11]).toEqual value: 'd', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[12][12]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.terminator.java']
+
+    expect(lines[13][1]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.object.array.java']
+    expect(lines[13][2]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.object.array.java', 'punctuation.bracket.square.java']
+    expect(lines[13][3]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.object.array.java', 'punctuation.bracket.square.java']
+    expect(lines[13][5]).toEqual value: 'primitiveArray', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
To avoid matching strings like `Something <= OtherThing` where the
`<` of the comparison operator was mistaken for a generic, require
there to be at least one storage type and at least one identifier.

Dollar are valid identifiers, added that in a few places it was
missing.

Also simplifies some regexes. E.g. `\w` matches `a-zA-Z0-9_` so
some redundant chars could be removed.