### PR TITLE
Fix `final` as modifier in method parameters

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -990,7 +990,7 @@
     'patterns': [
       {
         # `final` keyword must have at least one subsequent space before variable type
-        'match': '(final)\\s+'
+        'match': '\\b(final)\\b'
         'captures':
           '1':
             'name': 'storage.modifier.java'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -989,10 +989,8 @@
   'parameters':
     'patterns': [
       {
-        'match': '\\b(final)\\b'
-        'captures':
-          '1':
-            'name': 'storage.modifier.java'
+        'match': '\\bfinal\\b'
+        'name': 'storage.modifier.java'
       }
       {
         'include': '#annotations'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -989,7 +989,6 @@
   'parameters':
     'patterns': [
       {
-        # `final` keyword must have at least one subsequent space before variable type
         'match': '\\b(final)\\b'
         'captures':
           '1':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -989,8 +989,11 @@
   'parameters':
     'patterns': [
       {
-        'match': 'final'
-        'name': 'storage.modifier.java'
+        # `final` keyword must have at least one subsequent space before variable type
+        'match': '(final)\\s+'
+        'captures':
+          '1':
+            'name': 'storage.modifier.java'
       }
       {
         'include': '#annotations'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -236,21 +236,24 @@ describe 'Java grammar', ->
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
 
   it 'tokenizes `final` in inline method parameter', ->
-    {tokens} = grammar.tokenizeLine 'public int doSomething(int finalScore) { return finalScore; }'
+    {tokens} = grammar.tokenizeLine 'public int doSomething(final int finalScore) { return finalScore; }'
 
-    expect(tokens[7]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.function-call.java']
-    expect(tokens[13]).toEqual value: ' finalScore', scopes: ['source.java']
+    expect(tokens[6]).toEqual value: 'final', scopes: ['source.java', 'meta.function-call.java', 'storage.modifier.java']
+    expect(tokens[9]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.function-call.java']
+    expect(tokens[15]).toEqual value: ' finalScore', scopes: ['source.java']
 
   it 'tokenizes `final` inside class method parameter', ->
     lines = grammar.tokenizeLines '''
       class A
       {
-        public int doSomething(int finalScore) { return finalScore; }
+        public int doSomething(final int finalScore) {
+          return finalScore;
+        }
       }
     '''
 
-    expect(lines[2][9]).toEqual value: 'score', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
-    expect(lines[2][15]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
+    expect(lines[2][11]).toEqual value: 'finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[3][2]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
 
   it 'tokenizes method-local variables', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -235,7 +235,7 @@ describe 'Java grammar', ->
     expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
 
-  it 'tokenizes `final` inside class method parameter', ->
+  it 'tokenizes `final` in class method', ->
     lines = grammar.tokenizeLines '''
       class A
       {

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -235,25 +235,21 @@ describe 'Java grammar', ->
     expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
 
-  it 'tokenizes `final` in inline method parameter', ->
-    {tokens} = grammar.tokenizeLine 'public int doSomething(final int finalScore) { return finalScore; }'
-
-    expect(tokens[6]).toEqual value: 'final', scopes: ['source.java', 'meta.function-call.java', 'storage.modifier.java']
-    expect(tokens[9]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.function-call.java']
-    expect(tokens[15]).toEqual value: ' finalScore', scopes: ['source.java']
-
   it 'tokenizes `final` inside class method parameter', ->
     lines = grammar.tokenizeLines '''
       class A
       {
-        public int doSomething(final int finalScore)
+        public int doSomething(final int finalScore, final int scorefinal)
         {
           return finalScore;
         }
       }
     '''
 
+    expect(lines[2][7]).toEqual value: 'final', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.modifier.java']
     expect(lines[2][11]).toEqual value: 'finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[2][14]).toEqual value: 'final', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.modifier.java']
+    expect(lines[2][18]).toEqual value: 'scorefinal', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
     expect(lines[4][2]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
 
   it 'tokenizes `final` in class fields', ->

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -246,14 +246,29 @@ describe 'Java grammar', ->
     lines = grammar.tokenizeLines '''
       class A
       {
-        public int doSomething(final int finalScore) {
+        public int doSomething(final int finalScore)
+        {
           return finalScore;
         }
       }
     '''
 
     expect(lines[2][11]).toEqual value: 'finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
-    expect(lines[3][2]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
+    expect(lines[4][2]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
+
+  it 'tokenizes `final` in class fields', ->
+    lines = grammar.tokenizeLines '''
+      class A
+      {
+        private final int finala = 0;
+        final private int bfinal = 1;
+      }
+    '''
+
+    expect(lines[2][3]).toEqual value: 'final', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.modifier.java']
+    expect(lines[2][7]).toEqual value: 'finala', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[3][1]).toEqual value: 'final', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.modifier.java']
+    expect(lines[3][7]).toEqual value: 'bfinal', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
   it 'tokenizes method-local variables', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -235,6 +235,23 @@ describe 'Java grammar', ->
     expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
 
+  it 'tokenizes `final` in inline method parameter', ->
+    {tokens} = grammar.tokenizeLine 'public int doSomething(int finalScore) { return finalScore; }'
+
+    expect(tokens[7]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.function-call.java']
+    expect(tokens[13]).toEqual value: ' finalScore', scopes: ['source.java']
+
+  it 'tokenizes `final` inside class method parameter', ->
+    lines = grammar.tokenizeLines '''
+      class A
+      {
+        public int doSomething(int finalScore) { return finalScore; }
+      }
+    '''
+
+    expect(lines[2][9]).toEqual value: 'score', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[2][15]).toEqual value: ' finalScore', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
+
   it 'tokenizes method-local variables', ->
     lines = grammar.tokenizeLines '''
       class A


### PR DESCRIPTION
This PR fixes issue when method parameter name that starts with `final`, e.g. `finalScore` would be highlighted as `storage.modifier.java` alongside with actual modifier in front of type. Note that this only occurs inside class body.

Here is an example:
![sample-1](https://cloud.githubusercontent.com/assets/7788766/16260926/86734d26-38bd-11e6-998b-9ded59332459.png)

Patch fixes it by checking word boundary for `final` modifier keyword. In cases where it is part of the variable name, the correct `variable.parameter.java` is assigned to it.
After fix:
![sample-2](https://cloud.githubusercontent.com/assets/7788766/16260959/ab4e7b84-38bd-11e6-86e7-5c516c9ad7f4.png)
