### PR TITLE
Add Unified Expression Language (EL) and include it in JSP

### DIFF
--- a/grammars/java server pages (jsp).cson
+++ b/grammars/java server pages (jsp).cson
@@ -92,7 +92,7 @@
     'name': 'meta.embedded.line.el_expression.jsp'
     'patterns': [
       {
-        'include': 'source.java'
+        'include': 'source.java.el'
       }
     ]
   'expression':

--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -1,95 +1,88 @@
 'scopeName': 'source.java.el'
 'patterns': [
   {
-    'include': '#el'
+    'name': 'keyword.control.ternary.java.el'
+    'match': '\\?|(?<=\\s):'
   }
-]
-'repository':
-  'el':
+  {
+    'name': 'keyword.operator.comparison.java.el'
+    'match': '((==|!=|<=|>=|<|>)|\\b(eq|ne|le|ge|lt|gt)\\b)'
+  }
+  {
+    'name': 'keyword.operator.empty.java.el'
+    'match': '\\b(empty)\\b'
+  }
+  {
+    'name': 'keyword.operator.arithmetic.java.el'
+    'match': '(?:(\\-|\\+|\\*|\\/|%)|\\b(div|mod)\\b)'
+  }
+  {
+    'name': 'keyword.operator.logical.java.el'
+    'match': '(?:(!|&&|\\|\\|)|\\b(not|and|or)\\b)'
+  }
+  {
+    'name': 'namespace.java.el'
+    'match': '[a-zA-Z]+(:)'
+    'captures':
+      '1':
+        'name': 'punctuation.separator.namespace.java.el'
+  }
+  {
+    'match': ','
+    'name': 'meta.delimiter.java.el'
+  }
+  {
+    'match': '\\(|\\)'
+    'name': 'meta.brace.round.java.el'
+  }
+  {
+    'match': '\\[|\\]'
+    'name': 'meta.brace.square.java.el'
+  }
+  {
+    'name': 'constant.boolean.java.el'
+    'match': '\\b(true|false)\\b'
+  }
+  {
+    'name': 'constant.null.java.el'
+    'match': '\\bnull\\b'
+  }
+  {
+    'name': 'constant.numeric.java.el'
+    'match': '\\b([0-9]+\\.[0-9]+|[0-9]+)\\b'
+  }
+  {
+    'name': 'string.quoted.single.java.el'
+    'begin': '\''
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.java.el'
+    'end': '\''
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.java.el'
     'patterns': [
       {
-        'name': 'keyword.control.ternary.java.el'
-        'match': '\\?|(?<=\\s):'
-      }
-      {
-        'name': 'keyword.operator.comparison.java.el'
-        'match': '((==|!=|<=|>=|<|>)|\\b(eq|ne|le|ge|lt|gt)\\b)'
-      }
-      {
-        'name': 'keyword.operator.empty.java.el'
-        'match': '\\b(empty)\\b'
-      }
-      {
-        'name': 'keyword.operator.arithmetic.java.el'
-        'match': '(?:(\\-|\\+|\\*|\\/|%)|\\b(div|mod)\\b)'
-      }
-      {
-        'name': 'keyword.operator.logical.java.el'
-        'match': '(?:(!|&&|\\|\\|)|\\b(not|and|or)\\b)'
-      }
-      {
-        'name': 'namespace.java.el'
-        'match': '[a-zA-Z]+(:)'
-        'captures':
-          '1':
-            'name': 'punctuation.separator.namespace.java.el'
-      }
-      {
-        'match': ','
-        'name': 'meta.delimiter.java.el'
-      }
-      {
-        'match': '\\(|\\)'
-        'name': 'meta.brace.round.java.el'
-      }
-      {
-        'match': '\\[|\\]'
-        'name': 'meta.brace.square.java.el'
-      }
-      {
-        'name': 'constant.boolean.java.el'
-        'match': '\\b(true|false)\\b'
-      }
-      {
-        'name': 'constant.null.java.el'
-        'match': '\\bnull\\b'
-      }
-      {
-        'name': 'constant.numeric.java.el'
-        'match': '\\b([0-9]+\\.[0-9]+|[0-9]+)\\b'
-      }
-      {
-        'name': 'string.quoted.single.java.el'
-        'begin': '\''
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.java.el'
-        'end': '\''
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.java.el'
-        'patterns': [
-          {
-            'name': 'constant.character.escape.java.el'
-            'match': '\\\\.'
-          }
-        ]
-      }
-      {
-        'name': 'string.quoted.double.java.el'
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.java.el'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.java.el'
-        'patterns': [
-          {
-            'name': 'constant.character.escape.java.el'
-            'match': '\\\\.'
-          }
-        ]
+        'name': 'constant.character.escape.java.el'
+        'match': '\\\\.'
       }
     ]
+  }
+  {
+    'name': 'string.quoted.double.java.el'
+    'begin': '"'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.java.el'
+    'end': '"'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.java.el'
+    'patterns': [
+      {
+        'name': 'constant.character.escape.java.el'
+        'match': '\\\\.'
+      }
+    ]
+  }
+]

--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -1,5 +1,4 @@
 'scopeName': 'source.java.el'
-'name': 'Unified Expression Language (EL)'
 'fileTypes': []
 'patterns': [
   {

--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -1,0 +1,94 @@
+'scopeName': 'source.java.el'
+'name': 'Unified Expression Language (EL)'
+'fileTypes': []
+'patterns': [
+  {
+    'include': '#el'
+  }
+]
+'repository':
+  'el':
+    'patterns': [
+      {
+        'name': 'keyword.control.ternary.java.el'
+        'match': '\\?|\\s+:'
+      }
+      {
+        'name': 'keyword.operator.comparison.java.el'
+        'match': '(?:(==|!=|<=|>=|<>|<|>)|\\b(eq|ne|le|ge|lt|gt)\\b)'
+      }
+      {
+        'name': 'keyword.operator.empty.java.el'
+        'match': '\\b(empty)\\b'
+      }
+      {
+        'name': 'keyword.operator.arithmetic.java.el'
+        'match': '(?:(\\-|\\+|\\*|\\/|%)|\\b(div|mod)\\b)'
+      }
+      {
+        'name': 'keyword.operator.logical.java.el'
+        'match': '(?:(!|&&|\\|\\|)|\\b(not|and|or)\\b)'
+      }
+      {
+        'name': 'namespace.java.el'
+        'match': '[a-zA-Z]+:'
+      }
+      {
+        'match': ','
+        'name': 'meta.delimiter.java.el'
+      }
+      {
+        'match': '\\(|\\)'
+        'name': 'meta.brace.round.java.el'
+      }
+      {
+        'match': '\\[|\\]'
+        'name': 'meta.brace.square.java.el'
+      }
+      {
+        'name': 'constant.language.boolean.java.el'
+        'match': '\\b(true|false)\\b'
+      }
+      {
+        'name': 'constant.language.null.java.el'
+        'match': '\\bnull\\b'
+      }
+      {
+        'name': 'constant.numeric.java'
+        'match': '\\b([0-9]+|[0-9]+\\.[0-9]*)\\b'
+      }
+      {
+        'name': 'string.quoted.single.java.el'
+        'begin': '\''
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.java.el'
+        'end': '\''
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.java.el'
+        'patterns': [
+          {
+            'name': 'constant.character.escape.java.el'
+            'match': '\\\\.'
+          }
+        ]
+      }
+      {
+        'name': 'string.quoted.double.java.el'
+        'begin': '"'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.string.begin.java.el'
+        'end': '"'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.java.el'
+        'patterns': [
+          {
+            'name': 'constant.character.escape.java.el'
+            'match': '\\\\.'
+          }
+        ]
+      }
+    ]

--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -1,5 +1,4 @@
 'scopeName': 'source.java.el'
-'fileTypes': []
 'patterns': [
   {
     'include': '#el'

--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -9,11 +9,11 @@
     'patterns': [
       {
         'name': 'keyword.control.ternary.java.el'
-        'match': '\\?|\\s+:'
+        'match': '\\?|(?<=\\s):'
       }
       {
         'name': 'keyword.operator.comparison.java.el'
-        'match': '(?:(==|!=|<=|>=|<>|<|>)|\\b(eq|ne|le|ge|lt|gt)\\b)'
+        'match': '((==|!=|<=|>=|<|>)|\\b(eq|ne|le|ge|lt|gt)\\b)'
       }
       {
         'name': 'keyword.operator.empty.java.el'
@@ -29,7 +29,10 @@
       }
       {
         'name': 'namespace.java.el'
-        'match': '[a-zA-Z]+:'
+        'match': '[a-zA-Z]+(:)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.namespace.java.el'
       }
       {
         'match': ','
@@ -44,16 +47,16 @@
         'name': 'meta.brace.square.java.el'
       }
       {
-        'name': 'constant.language.boolean.java.el'
+        'name': 'constant.boolean.java.el'
         'match': '\\b(true|false)\\b'
       }
       {
-        'name': 'constant.language.null.java.el'
+        'name': 'constant.null.java.el'
         'match': '\\bnull\\b'
       }
       {
-        'name': 'constant.numeric.java'
-        'match': '\\b([0-9]+|[0-9]+\\.[0-9]*)\\b'
+        'name': 'constant.numeric.java.el'
+        'match': '\\b([0-9]+\\.[0-9]+|[0-9]+)\\b'
       }
       {
         'name': 'string.quoted.single.java.el'

--- a/spec/unified-el-spec.coffee
+++ b/spec/unified-el-spec.coffee
@@ -1,0 +1,188 @@
+describe 'Unified expression language grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-java')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('source.java.el')
+
+  it 'parses the grammar', ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe 'source.java.el'
+
+  describe 'operators', ->
+    it 'tokenizes the ternary operator', ->
+      {tokens} = grammar.tokenizeLine 'true ? 0 : 1'
+
+      expect(tokens[2]).toEqual value: '?', scopes: ['source.java.el', 'keyword.control.ternary.java.el']
+      expect(tokens[6]).toEqual value: ':', scopes: ['source.java.el', 'keyword.control.ternary.java.el']
+
+    it 'parses the comparison operator `==`', ->
+      {tokens} = grammar.tokenizeLine '1 == 1'
+      expect(tokens[2]).toEqual value: '==', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `!=`', ->
+      {tokens} = grammar.tokenizeLine '1 != 1'
+      expect(tokens[2]).toEqual value: '!=', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `<=`', ->
+      {tokens} = grammar.tokenizeLine '1 <= 1'
+      expect(tokens[2]).toEqual value: '<=', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `>=`', ->
+      {tokens} = grammar.tokenizeLine '1 >= 1'
+      expect(tokens[2]).toEqual value: '>=', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `<`', ->
+      {tokens} = grammar.tokenizeLine '1 < 1'
+      expect(tokens[2]).toEqual value: '<', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `>`', ->
+      {tokens} = grammar.tokenizeLine '1 > 1'
+      expect(tokens[2]).toEqual value: '>', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `eq`', ->
+      {tokens} = grammar.tokenizeLine '1 eq 1'
+      expect(tokens[2]).toEqual value: 'eq', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `ne`', ->
+      {tokens} = grammar.tokenizeLine '1 ne 1'
+      expect(tokens[2]).toEqual value: 'ne', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `le`', ->
+      {tokens} = grammar.tokenizeLine '1 le 1'
+      expect(tokens[2]).toEqual value: 'le', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `gt`', ->
+      {tokens} = grammar.tokenizeLine '1 gt 1'
+      expect(tokens[2]).toEqual value: 'gt', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `lt`', ->
+      {tokens} = grammar.tokenizeLine '1 lt 1'
+      expect(tokens[2]).toEqual value: 'lt', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the comparison operator `gt`', ->
+      {tokens} = grammar.tokenizeLine '1 gt 1'
+      expect(tokens[2]).toEqual value: 'gt', scopes: ['source.java.el', 'keyword.operator.comparison.java.el']
+
+    it 'parses the empty operators', ->
+      {tokens} = grammar.tokenizeLine 'empty foo'
+      expect(tokens[0]).toEqual value: 'empty', scopes: ['source.java.el', 'keyword.operator.empty.java.el']
+
+    it 'parses the arithmetic operator `-`', ->
+      {tokens} = grammar.tokenizeLine '1 - 1'
+      expect(tokens[2]).toEqual value: '-', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `+`', ->
+      {tokens} = grammar.tokenizeLine '1 + 1'
+      expect(tokens[2]).toEqual value: '+', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `*`', ->
+      {tokens} = grammar.tokenizeLine '1 * 1'
+      expect(tokens[2]).toEqual value: '*', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `/`', ->
+      {tokens} = grammar.tokenizeLine '1 / 1'
+      expect(tokens[2]).toEqual value: '/', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `%`', ->
+      {tokens} = grammar.tokenizeLine '1 % 1'
+      expect(tokens[2]).toEqual value: '%', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `div`', ->
+      {tokens} = grammar.tokenizeLine '1 div 1'
+      expect(tokens[2]).toEqual value: 'div', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the arithmetic operator `mod`', ->
+      {tokens} = grammar.tokenizeLine '1 mod 1'
+      expect(tokens[2]).toEqual value: 'mod', scopes: ['source.java.el', 'keyword.operator.arithmetic.java.el']
+
+    it 'parses the logical operator `!`', ->
+      {tokens} = grammar.tokenizeLine '!foo'
+      expect(tokens[0]).toEqual value: '!', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+    it 'parses the logical operator `&&`', ->
+      {tokens} = grammar.tokenizeLine '1 && 1'
+      expect(tokens[2]).toEqual value: '&&', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+    it 'parses the logical operator `||`', ->
+      {tokens} = grammar.tokenizeLine '1 || 1'
+      expect(tokens[2]).toEqual value: '||', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+    it 'parses the logical operator `not`', ->
+      {tokens} = grammar.tokenizeLine '1 not 1'
+      expect(tokens[2]).toEqual value: 'not', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+    it 'parses the logical operator `and`', ->
+      {tokens} = grammar.tokenizeLine '1 and 1'
+      expect(tokens[2]).toEqual value: 'and', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+    it 'parses the logical operator `or`', ->
+      {tokens} = grammar.tokenizeLine '1 or 1'
+      expect(tokens[2]).toEqual value: 'or', scopes: ['source.java.el', 'keyword.operator.logical.java.el']
+
+  describe 'literals', ->
+    it 'parses boolean literals', ->
+      {tokens} = grammar.tokenizeLine 'true'
+      expect(tokens[0]).toEqual value: 'true', scopes: ['source.java.el', 'constant.boolean.java.el']
+
+      {tokens} = grammar.tokenizeLine 'false'
+      expect(tokens[0]).toEqual value: 'false', scopes: ['source.java.el', 'constant.boolean.java.el']
+
+    it 'parses the null literal', ->
+      {tokens} = grammar.tokenizeLine 'null'
+
+    it 'parses numeric literals', ->
+      {tokens} = grammar.tokenizeLine '0'
+      expect(tokens[0]).toEqual value: '0', scopes: ['source.java.el', 'constant.numeric.java.el']
+
+      {tokens} = grammar.tokenizeLine '9804'
+      expect(tokens[0]).toEqual value: '9804', scopes: ['source.java.el', 'constant.numeric.java.el']
+
+      {tokens} = grammar.tokenizeLine '0.54'
+      expect(tokens[0]).toEqual value: '0.54', scopes: ['source.java.el', 'constant.numeric.java.el']
+
+      {tokens} = grammar.tokenizeLine '13.12'
+      expect(tokens[0]).toEqual value: '13.12', scopes: ['source.java.el', 'constant.numeric.java.el']
+
+    it 'tokenizes single quoted string literals', ->
+      {tokens} = grammar.tokenizeLine "'foo\\n bar \\\'baz'"
+      expect(tokens[0]).toEqual value: "'", scopes: ['source.java.el', 'string.quoted.single.java.el', 'punctuation.definition.string.begin.java.el']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.java.el', 'string.quoted.single.java.el']
+      expect(tokens[2]).toEqual value: '\\n', scopes: ['source.java.el', 'string.quoted.single.java.el', 'constant.character.escape.java.el']
+      expect(tokens[3]).toEqual value: ' bar ', scopes: ['source.java.el', 'string.quoted.single.java.el']
+      expect(tokens[4]).toEqual value: '\\\'', scopes: ['source.java.el', 'string.quoted.single.java.el', 'constant.character.escape.java.el']
+      expect(tokens[5]).toEqual value: 'baz', scopes: ['source.java.el', 'string.quoted.single.java.el']
+      expect(tokens[6]).toEqual value: "'", scopes: ['source.java.el', 'string.quoted.single.java.el', 'punctuation.definition.string.end.java.el']
+
+    it 'tokenizes double quoted string literals', ->
+      {tokens} = grammar.tokenizeLine '"foo\\n bar \\\"baz"'
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.java.el', 'string.quoted.double.java.el', 'punctuation.definition.string.begin.java.el']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.java.el', 'string.quoted.double.java.el']
+      expect(tokens[2]).toEqual value: '\\n', scopes: ['source.java.el', 'string.quoted.double.java.el', 'constant.character.escape.java.el']
+      expect(tokens[3]).toEqual value: ' bar ', scopes: ['source.java.el', 'string.quoted.double.java.el']
+      expect(tokens[4]).toEqual value: '\\\"', scopes: ['source.java.el', 'string.quoted.double.java.el', 'constant.character.escape.java.el']
+      expect(tokens[5]).toEqual value: 'baz', scopes: ['source.java.el', 'string.quoted.double.java.el']
+      expect(tokens[6]).toEqual value: '"', scopes: ['source.java.el', 'string.quoted.double.java.el', 'punctuation.definition.string.end.java.el']
+
+  it 'tokenizes function calls', ->
+    {tokens} = grammar.tokenizeLine 'fn:split(foo, bar)'
+
+    expect(tokens[0]).toEqual value: 'fn', scopes: ['source.java.el', 'namespace.java.el']
+    expect(tokens[1]).toEqual value: ':', scopes: ['source.java.el', 'namespace.java.el', 'punctuation.separator.namespace.java.el']
+    expect(tokens[2]).toEqual value: 'split', scopes: ['source.java.el']
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.java.el', 'meta.brace.round.java.el']
+    expect(tokens[4]).toEqual value: 'foo', scopes: ['source.java.el']
+    expect(tokens[5]).toEqual value: ',', scopes: ['source.java.el', 'meta.delimiter.java.el']
+    expect(tokens[6]).toEqual value: ' bar', scopes: ['source.java.el']
+    expect(tokens[7]).toEqual value: ')', scopes: ['source.java.el', 'meta.brace.round.java.el']
+
+  it 'tokenizes a computed property access', ->
+    {tokens} = grammar.tokenizeLine 'foo[0]'
+
+    expect(tokens[0]).toEqual value: 'foo', scopes: ['source.java.el']
+    expect(tokens[1]).toEqual value: '[', scopes: ['source.java.el', 'meta.brace.square.java.el']
+    expect(tokens[2]).toEqual value: '0', scopes: ['source.java.el', 'constant.numeric.java.el']
+    expect(tokens[3]).toEqual value: ']', scopes: ['source.java.el', 'meta.brace.square.java.el']


### PR DESCRIPTION
This is my attempt to implement #64. 
Because other technologies (like JSF) use EL as well, the EL grammar is added as its own language file.

There are a few things I am unsure about:
- Is `source.java.el` a good scopeName?  
  The problem I see is that snippets, autocomplete providers and alike which are intended to work with Java will also apply to EL.
- Should I add test and if so, how?

Some JSP code I used for testing: 

``` jsp
${foo}
${fooBar}
${42}
${foo42}
${42foo}
${fooeq}
${foodiv}
${foomod}
${notfoo}
${footrue}
${42+4}
${42==4}
${'bar \' \\ sdaff " dsaf'}
${"dsa f ' 'dsaf sdf \\ \" asd fds af"}
${"foo"eq"foo"}
${foo eq bar}
${foo == bar}
${foo==bar}
${foo ne bar}
${foo !=bar}
${0 lt 5}
${0 < 5}
${8 gt 5}
${8 > 5}
${80 le 5}
${80 <= 5}
${42 ge 0}
${42 >= 0}
${42 + 0}
${42 - 0}
${42 * 0}
${42 div 0}
${42 / 0}
${42 mod 0}
${42 % 0}
${not bar}
${!bar}
${"foo" eq 'foo'}
${"\"'" eq '"\''}
${true}
${false}
${fn:contains('foo', 'bar')}
${foo ? 'foo' : 'bar'}
${foo['bar']}
${foo[42]}
${(42 lt 5) and (45 ne 8)}
${fn:indexOf('fooo', 'o')}
${not empty bar and fn:contains(bar, 'foo')}

<c:if test="${not empty bar and fn:contains(bar, 'foo')}">
    ${bar}
    ${setFoo(true)}
</c:if>
```
