### PR TITLE
Fix static initializer

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -299,6 +299,9 @@
         'include': '#generics'
       }
       {
+        'include': '#static-initializer'
+      }
+      {
         'include': '#methods'
       }
       {
@@ -326,6 +329,16 @@
     'patterns': [
       {
         'include': '#code'
+      }
+    ]
+  'static-initializer':
+    'patterns': [
+      {
+        'include': '#anonymous-block-and-instance-initializer'
+      }
+      {
+        'match': 'static'
+        'name': 'storage.modifier.java'
       }
     ]
   'code':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1003,3 +1003,64 @@ describe 'Java grammar', ->
     expect(lines[8][5]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
     expect(lines[8][6]).toEqual value: 'method$(int a)', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
     expect(lines[8][7]).toEqual value: ' label {@link Class#method()}}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+
+  it 'tokenizes class-body block initializer', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        public static HashSet<Integer> set = new HashSet<Integer>();
+        {
+          int a = 1;
+          set.add(a);
+        }
+      }
+      '''
+
+    expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.section.block.begin.bracket.curly.java']
+    expect(lines[4][1]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[4][3]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[5][1]).toEqual value: 'set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'variable.other.object.java']
+    expect(lines[5][3]).toEqual value: 'add', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method-call.java', 'entity.name.function.java']
+    expect(lines[6][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.section.block.end.bracket.curly.java']
+
+  it 'tokenizes method-body block initializer', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        public int func() {
+          List<Integer> list = new ArrayList<Integer>();
+          {
+            int a = 1;
+            list.add(a);
+          }
+          return 1;
+        }
+      }
+      '''
+
+    expect(lines[4][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'punctuation.section.block.begin.bracket.curly.java']
+    expect(lines[5][1]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[5][3]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[6][1]).toEqual value: 'list', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'variable.other.object.java']
+    expect(lines[6][3]).toEqual value: 'add', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.method-call.java', 'entity.name.function.java']
+    expect(lines[7][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'punctuation.section.block.end.bracket.curly.java']
+
+  it 'tokenizes static initializer', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        public static HashSet<Integer> set = new HashSet<Integer>();
+        static {
+          int a = 1;
+          set.add(a);
+        }
+      }
+      '''
+
+    expect(lines[3][1]).toEqual value: 'static', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.modifier.java']
+    expect(lines[3][3]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.section.block.begin.bracket.curly.java']
+    expect(lines[4][1]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[4][3]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[5][1]).toEqual value: 'set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'variable.other.object.java']
+    expect(lines[5][3]).toEqual value: 'add', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method-call.java', 'entity.name.function.java']
+    expect(lines[6][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.section.block.end.bracket.curly.java']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue with declaring static initializer as opposed to instance/method initializer. Currently if you write this in Java class:
```java
class Test {
  static HashSet<Integer> set = ...
  static {
    set.add(1);
  }
}
``` 
The inside of initializer is not highlighted correctly (see image below), and treated as partially written method syntax.

Note that instance/method initializers work correctly, pattern just does not understand `static` modifier prefix. I fixed by adding new pattern `static-initializer` that is built from `anonymous-block-and-instance-initializer` and `static` keyword, and added it into `class-body` scope. Also added tests for static/instance/method initializers.

<img width="480" alt="before" src="https://cloud.githubusercontent.com/assets/7788766/21488879/971ebd84-cc49-11e6-90fb-7789ddcf12ba.png">
<img width="493" alt="after" src="https://cloud.githubusercontent.com/assets/7788766/21488883/9dbcc1ae-cc49-11e6-9c49-e07801d21e6e.png">

### Alternate Designs
I considered first to add `static-initializer` totally separately with its own syntax, but that introduces more code changes and duplicates the effort of having two code blocks that handle the same functionality, really. I was also thinking about just modifying `anonymous-block-and-instance-initializer` itself to handle `static` in front of it, but thought that capturing optional group was not the best approach (could not see examples in existing code either).

### Benefits
Fixes highlighting of static initializers.

### Possible Drawbacks
Possibly breaks other parts of code, though it passes unit-tests.

### Applicable Issues
Currently there is a bug/feature of highlighting `static` inside method body. 
```java
class Test {
  public void func() {
    static {
      int a = 1;
    }
  }
}
```
This happens in master branch, compiler complains about this code. I am not sure if this is expected, and/or I need to fix it in this PR.
