### PR TITLE
Attempt to fix overlap of generics and if-else block

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -912,7 +912,8 @@
       }
       {
         # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b\\s*(?=<)'
+        # Also expression ensures that generic is specified on single line with closing '>'
+        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b\\s*(?=<.*>)'
         'beginCaptures':
           '0':
             'name': 'storage.type.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -451,6 +451,79 @@ describe 'Java grammar', ->
     expect(lines[6][3]).toEqual value: 'Object', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.java']
     expect(lines[6][5]).toEqual value: 'otherMethod', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
 
+  it 'tokenizes generics in if-else code block', ->
+    lines = grammar.tokenizeLines '''
+      void func() {
+        int a = 1, A = 2, b = 0;
+        if (A < a) {
+          b = a;
+        }
+        String S = "str>str";
+      }
+    '''
+
+    expect(lines[2][4]).toEqual value: 'A', scopes: ['source.java', 'storage.type.java']
+    expect(lines[2][6]).toEqual value: '<', scopes: ['source.java', 'keyword.operator.comparison.java']
+    expect(lines[5][1]).toEqual value: 'String', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[5][3]).toEqual value: 'S', scopes: ['source.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[5][5]).toEqual value: '=', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.operator.assignment.java']
+    # check that string does not extend to/include ';'
+    expect(lines[5][10]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
+
+  it 'tokenizes generics with multiple conditions in if-else code block', ->
+    lines = grammar.tokenizeLines '''
+      void func() {
+        int a = 1, A = 2, b = 0;
+        if (A < a && b < a) {
+          b = a;
+        }
+      }
+    '''
+
+    expect(lines[2][4]).toEqual value: 'A', scopes: ['source.java', 'storage.type.java']
+    expect(lines[2][6]).toEqual value: '<', scopes: ['source.java', 'keyword.operator.comparison.java']
+    expect(lines[2][8]).toEqual value: '&&', scopes: ['source.java', 'keyword.operator.logical.java']
+    # 'b' should be just a variable, not part of generic
+    expect(lines[2][9]).toEqual value: ' b ', scopes: ['source.java']
+    expect(lines[2][10]).toEqual value: '<', scopes: ['source.java', 'keyword.operator.comparison.java']
+
+  it 'tokenizes generics before if-else code block, not including it', ->
+    lines = grammar.tokenizeLines '''
+      void func() {
+        int a = 1, A = 2;
+        ArrayList<A extends B<C>> list;
+        list = new ArrayList<>();
+        if (A < a) { }
+      }
+    '''
+
+    expect(lines[2][1]).toEqual value: 'ArrayList', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][2]).toEqual value: '<', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][11]).toEqual value: '>', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    # right part of the assignment
+    expect(lines[3][5]).toEqual value: 'ArrayList', scopes: ['source.java', 'storage.type.java']
+    expect(lines[3][6]).toEqual value: '<', scopes: ['source.java', 'punctuation.bracket.angle.java']
+    expect(lines[3][7]).toEqual value: '>', scopes: ['source.java', 'punctuation.bracket.angle.java']
+    # 'if' code block
+    expect(lines[4][4]).toEqual value: 'A', scopes: ['source.java', 'storage.type.java']
+    expect(lines[4][6]).toEqual value: '<', scopes: ['source.java', 'keyword.operator.comparison.java']
+
+  it 'tokenizes generics as a function return type', ->
+    lines = grammar.tokenizeLines '''
+      ArrayList<A extends B, C> func() {
+        return null;
+      }
+    '''
+
+    expect(lines[0][0]).toEqual value: 'ArrayList', scopes: ['source.java', 'storage.type.java']
+    expect(lines[0][1]).toEqual value: '<', scopes: ['source.java', 'punctuation.bracket.angle.java']
+    expect(lines[0][2]).toEqual value: 'A', scopes: ['source.java', 'storage.type.generic.java']
+    expect(lines[0][4]).toEqual value: 'extends', scopes: ['source.java', 'storage.modifier.extends.java']
+    expect(lines[0][6]).toEqual value: 'B', scopes: ['source.java', 'storage.type.generic.java']
+    expect(lines[0][7]).toEqual value: ',', scopes: ['source.java', 'punctuation.separator.delimiter.java']
+    expect(lines[0][9]).toEqual value: 'C', scopes: ['source.java', 'storage.type.generic.java']
+    expect(lines[0][10]).toEqual value: '>', scopes: ['source.java', 'punctuation.bracket.angle.java']
+
   it 'tokenizes lambda expressions', ->
     {tokens} = grammar.tokenizeLine '(String s1) -> s1.length() - outer.length();'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
In released version of Atom 1.13.0 and in current master branch there is an issue when expression inside `if (...)` is parsed as generics when capitalized variable is used with `<` and some other combinations, see screen shots below. This can even affect all subsequent highlighting as shown on image below (with string). For most part it is merely minor, out of ordinary highlighting of variables, not critical at all.

![java-generic-overlap](https://cloud.githubusercontent.com/assets/7788766/22488847/2c89f244-e879-11e6-9b5b-341156067eeb.png)
![java-generic-overlap-3](https://cloud.githubusercontent.com/assets/7788766/22488858/40302dd6-e879-11e6-82f1-639205447315.png)

- Examples that break hightlighting: `if (A < a) { ... }`, `if (A < a && b < a) { ... }`, and `if (A < a || b > a) { ... }`
- Examples that work: `if (a < A) { ... }`, `if (a < b) { ... }`

I tried fixing most of the cases, currently I make sure that generic ends up on the same line. From what I have seen people keep generics expression on single line, and thought it would be a fair assumption to make. Code **does not fix** situations with logical operators, e.g. `&&`, `||`.  I also added tests for generics, which I think could be useful even if PR is closed (I can add tests separately).

After:
![java-generic-overlap-after-1](https://cloud.githubusercontent.com/assets/7788766/22489094/6f8a7b8a-e87a-11e6-86de-d4b6b36a436e.png)
![java-generic-overlap-after-2](https://cloud.githubusercontent.com/assets/7788766/22489099/71b706f8-e87a-11e6-82ab-19f355aaa641.png)

### Alternate Designs
As an alternative approach I was considering capturing `condition-block` similar to other patterns like `try-catch`, so we know that everything inside that block can be variable names and/or operators only. This would fix all cases above. I did not make the change for a reason of not being such critical at the moment and also wanted to hear from community, and discuss/approve approaches.  

### Benefits
Current solution is simple, alternative would require more code, but it would cover all cases and potentially more robust to further changes (+ easy to maintain over long regex).

### Possible Drawbacks
My change might affect some other untested cases.

### Applicable Issues

<!-- Enter any applicable Issues here -->
