### PR TITLE
Tokenize qualified storage types

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -949,7 +949,7 @@
         'include': '#generics'
       }
       {
-        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*([A-Z]+\\w*)\\b\\s*(?=\\[)'
+        'begin': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.period.java'
@@ -967,7 +967,7 @@
       }
       {
         # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b\\s*(?=<)'
+        'begin': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\s*(?=<)'
         'beginCaptures':
           '0':
             'name': 'storage.type.java'
@@ -982,11 +982,11 @@
       }
       {
         # If the above fails *then* just look for Wow
-        'match': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
+        'name': 'storage.type.java'
         'captures':
           '1':
             'name': 'punctuation.separator.period.java'
-        'name': 'storage.type.java'
       }
     ]
   'object-types-inherited':
@@ -995,7 +995,7 @@
         'include': '#generics'
       }
       {
-        'match': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
         'name': 'entity.other.inherited-class.java'
         'captures':
           '1':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1104,6 +1104,17 @@ describe 'Java grammar', ->
     expect(lines[13][3]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[13][5]).toEqual value: 'primitiveArray', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
+  it 'tokenizes qualified storage types', ->
+    lines = grammar.tokenizeLines '''
+      class Test {
+        private Test.Double something;
+      }
+    '''
+    expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java']
+    expect(lines[1][5]).toEqual value: 'Double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][7]).toEqual value: 'something', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
     class Test {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The code was mostly working, though for some reason it was targeting `[a-z]` instead of `[A-Z]`.  I'm fairly certain that I was the one who wrote that, though unfortunately I can't remember if I did it for a reason.  Specs all pass, so hopefully not!

### Alternate Designs

None.

### Benefits

Qualified storage types no longer get partially tokenized as a property.

### Possible Drawbacks

I believe none.

### Applicable Issues

Fixes #47