### PR TITLE
Check to make sure an identifier exists before tokenizing something as a storage type

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -949,7 +949,7 @@
         'include': '#generics'
       }
       {
-        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*([A-Z]+\\w*)\\b\\s*(?=\\[)'
+        'begin': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.period.java'
@@ -967,7 +967,7 @@
       }
       {
         # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b\\s*(?=<)'
+        'begin': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\s*(?=<)'
         'beginCaptures':
           '0':
             'name': 'storage.type.java'
@@ -982,11 +982,11 @@
       }
       {
         # If the above fails *then* just look for Wow
-        'match': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*\\b'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
+        'name': 'storage.type.java'
         'captures':
           '1':
             'name': 'punctuation.separator.period.java'
-        'name': 'storage.type.java'
       }
     ]
   'object-types-inherited':
@@ -995,7 +995,7 @@
         'include': '#generics'
       }
       {
-        'match': '\\b(?:[a-z]\\w*\\s*(\\.)\\s*)*[A-Z]+\\w*'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
         'name': 'entity.other.inherited-class.java'
         'captures':
           '1':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -982,7 +982,7 @@
       }
       {
         # If the above fails *then* just look for Wow
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*+(?=\\s*[\\w$])'
         'name': 'storage.type.java'
         'captures':
           '1':
@@ -995,7 +995,7 @@
         'include': '#generics'
       }
       {
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*+(?=\\s*[\\w$])'
         'name': 'entity.other.inherited-class.java'
         'captures':
           '1':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1118,11 +1118,11 @@ describe 'Java grammar', ->
   it 'does not tokenize uppercase variables as storage types', ->
     lines = grammar.tokenizeLines '''
       class Test {
-        private int G = 0;
-        G += 3;
+        private int HELLO = 0;
+        HELLO += 3;
       }
     '''
-    expect(lines[2][0]).toEqual value: '  G ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
+    expect(lines[2][0]).toEqual value: '  HELLO ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1115,6 +1115,15 @@ describe 'Java grammar', ->
     expect(lines[1][5]).toEqual value: 'Double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
     expect(lines[1][7]).toEqual value: 'something', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
+  it 'does not tokenize uppercase variables as storage types', ->
+    lines = grammar.tokenizeLines '''
+      class Test {
+        private int G = 0;
+        G += 3;
+      }
+    '''
+    expect(lines[2][0]).toEqual value: '  G ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
+
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
     class Test {

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1118,11 +1118,12 @@ describe 'Java grammar', ->
   it 'does not tokenize uppercase variables as storage types', ->
     lines = grammar.tokenizeLines '''
       class Test {
-        private int HELLO = 0;
         HELLO += 3;
+        Hello += 3;
       }
     '''
-    expect(lines[2][0]).toEqual value: '  HELLO ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
+    expect(lines[1][0]).toEqual value: '  HELLO ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
+    expect(lines[2][0]).toEqual value: '  Hello ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java']
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1104,6 +1104,17 @@ describe 'Java grammar', ->
     expect(lines[13][3]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[13][5]).toEqual value: 'primitiveArray', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
+  it 'tokenizes qualified storage types', ->
+    lines = grammar.tokenizeLines '''
+      class Test {
+        private Test.Double something;
+      }
+    '''
+    expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java']
+    expect(lines[1][5]).toEqual value: 'Double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][7]).toEqual value: 'something', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
     class Test {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Before, any variable that started with an uppercase letter (eg `Hello`) would be considered a storage type, even if there was no identifier following it (eg normal variable usage, `Hello = 3`).  This PR makes sure that an identifier follows a potential storage type before tokenizing it as one.

### Alternate Designs

None.

### Benefits

People who use uppercase variables will be happy.

### Possible Drawbacks

Multiline variable declarations with an object type no longer have their storage type tokenized.  I think this is a fair compromise, considering that the variable itself already isn't tokenized.
```java
class Test {
  String
  stuff = 0; // String and stuff won't be highlighted
```

### Applicable Issues

Fixes #76, depends on #77