### PR TITLE
Tokenize resources in try blocks

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -145,10 +145,6 @@
           {
             'include': '#code'
           }
-          {
-            'match': ','
-            'name': 'punctuation.separator.delimiter.java'
-          }
         ]
       }
       {
@@ -546,9 +542,6 @@
             'contentName': 'meta.try.body.java'
             'patterns': [
               {
-                'include': '#variables'
-              }
-              {
                 'include': '#code'
               }
             ]
@@ -592,9 +585,6 @@
             'contentName': 'meta.catch.body.java'
             'patterns': [
               {
-                'include': '#variables'
-              }
-              {
                 'include': '#code'
               }
             ]
@@ -621,9 +611,6 @@
             'end': '(?=})'
             'contentName': 'meta.finally.body.java'
             'patterns': [
-              {
-                'include': '#variables'
-              }
               {
                 'include': '#code'
               }
@@ -740,10 +727,6 @@
     'name': 'meta.function-call.java'
     'patterns': [
       {
-        'match': ','
-        'name': 'punctuation.separator.delimiter.java'
-      }
-      {
         'include': '#code'
       }
     ]
@@ -824,10 +807,6 @@
         'name': 'punctuation.definition.parameters.end.bracket.round.java'
     'name': 'meta.method-call.java'
     'patterns': [
-      {
-        'match': ','
-        'name': 'punctuation.separator.delimiter.java'
-      }
       {
         'include': '#code'
       }

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -522,6 +522,22 @@
         'name': 'meta.try.java'
         'patterns': [
           {
+            'begin': '\\('
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.section.try.resources.begin.bracket.round.java'
+            'end': '\\)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.try.resources.end.bracket.round.java'
+            'name': 'meta.try.resources.java'
+            'patterns': [
+              {
+                'include': '#code'
+              }
+            ]
+          }
+          {
             'begin': '{'
             'beginCaptures':
               '0':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1261,6 +1261,28 @@ describe 'Java grammar', ->
     expect(lines[8][11]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.catch.begin.bracket.curly.java']
     expect(lines[8][12]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.catch.end.bracket.curly.java']
 
+  it 'tokenizes try-catch blocks with resources', ->
+    lines = grammar.tokenizeLines '''
+      class Test {
+        private void fn() {
+          try (
+            BufferedReader in = new BufferedReader();
+          ) {
+            // stuff
+          }
+        }
+      }
+    '''
+
+    scopes = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.try.java']
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopes.concat ['keyword.control.try.java']
+    expect(lines[2][2]).toEqual value: ' ', scopes: scopes
+    expect(lines[2][3]).toEqual value: '(', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.begin.bracket.round.java']
+    expect(lines[3][1]).toEqual value: 'BufferedReader', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[4][1]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
+    expect(lines[4][2]).toEqual value: ' ', scopes: scopes
+    expect(lines[4][3]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
+
   it 'tokenizes comment inside method body', ->
     lines = grammar.tokenizeLines '''
       class Test


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenize resource declarations in try blocks, such as the following:
```java
try ( BufferedReader in = new BufferedReader(); )
{
  // stuff
}
```

### Alternate Designs

None.

### Benefits

See above.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #79