### PR TITLE
Tokenize inline new statements correctly

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -157,7 +157,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\))'
+    'end': '(?=;|\\)|,)'
     'patterns': [
       {
         'include': '#function-call'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -975,10 +975,12 @@ describe 'Java grammar', ->
     expect(tokens[14]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
     expect(tokens[15]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
-    {tokens} = grammar.tokenizeLine 'map.put(key, new Value(value));'
+    {tokens} = grammar.tokenizeLine 'map.put(key, new Value(value), "extra");'
 
     expect(tokens[12]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
-    expect(tokens[13]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[13]).toEqual value: ',', scopes: ['source.java', 'meta.method-call.java', 'punctuation.separator.delimiter.java']
+    expect(tokens[15]).toEqual value: '"', scopes: ['source.java', 'meta.method-call.java', 'string.quoted.double.java', 'punctuation.definition.string.begin.java']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
 
     lines = grammar.tokenizeLines '''
       map.put(key,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes the following scenario:
```java
object.method(1, new Integer(2), "3");
```

Before the `new` highlighting would fail to stop at the end of the Integer declaration and it would continue until the ending method parentheses, and the `"3"` would receive no highlighting.  Now new statements will also stop at a comma, as that signifies that we're inline.

### Alternate Designs

None

### Benefits

See above

### Possible Drawbacks

None

### Applicable Issues

None