### PR TITLE
Indent single-line if statements

### DIFF
--- a/settings/language-java.cson
+++ b/settings/language-java.cson
@@ -5,9 +5,9 @@
     'increaseIndentPattern': '''(?x)
       ^.*{[^}"\']*$                             # Opening bracket without closing bracket or quotes
       |
-      ^\\s*(else\\s+)?if\\s*\\([^\\)]+\\)\\s*$  # single-line if/else if (change to indentNextLinePattern when available)
+      ^\\s*(else\\s+)?if\\s*\\([^\\)]+\\)\\s*(//.*)?$  # single-line if/else if (change to indentNextLinePattern when available)
       |
-      ^\\s*else\\s*$                            # single-line else (change to indentNextLinePattern when available)
+      ^\\s*else\\s*(//.*)?$                            # single-line else (change to indentNextLinePattern when available)
     '''
     'decreaseIndentPattern': '^(.*\\*/)?\\s*}'
 '.text.html.jsp':

--- a/settings/language-java.cson
+++ b/settings/language-java.cson
@@ -2,8 +2,14 @@
   'editor':
     'commentStart': '// '
     'foldEndPattern': '^\\s*(\\}|// \\}\\}\\}$)'
-    'increaseIndentPattern': '^.*\\{(\\}|[^}"\']*)$|^\\s*(public|private|protected):\\s*$'
-    'decreaseIndentPattern': '^(.*\\*/)?\\s*\\}|^\\s*(public|private|protected):\\s*$'
+    'increaseIndentPattern': '''(?x)
+      ^.*{[^}"\']*$                             # Opening bracket without closing bracket or quotes
+      |
+      ^\\s*(else\\s+)?if\\s*\\([^\\)]+\\)\\s*$  # single-line if/else if (change to indentNextLinePattern when available)
+      |
+      ^\\s*else\\s*$                            # single-line else (change to indentNextLinePattern when available)
+    '''
+    'decreaseIndentPattern': '^(.*\\*/)?\\s*}'
 '.text.html.jsp':
   'editor':
     'foldEndPattern': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Auto-indent single-line if statements such as the following:
```java
if(true)
    // THIS SHOULD BE INDENTED
```
Same for `else if` and `else`.

In addition, I took the liberty of removing some very questionable auto-indent rules.  For example, `{}` would cause the next line to be indented.  Also, `public:` would be dedented, and the next line would be indented.  I don't believe this is valid Java syntax anyway, so I removed it.

### Alternate Designs

None

### Benefits

Auto-indentation of if statements

### Possible Drawbacks

One downside of this change is that it uses `increaseIndentPattern`, which means that after the line is indented, it does not get dedented.  This is unsatisfactory because single-line if statements should only have the following line indented.  As Atom currently does not support Textmate's `indentNextLinePattern`, this is the best that we can do at the moment.

### Applicable Issues

Fixes #10