### PR TITLE
Revert "Indent single-line if statements"

### DIFF
--- a/settings/language-java.cson
+++ b/settings/language-java.cson
@@ -2,14 +2,8 @@
   'editor':
     'commentStart': '// '
     'foldEndPattern': '^\\s*(\\}|// \\}\\}\\}$)'
-    'increaseIndentPattern': '''(?x)
-      ^.*{[^}"\']*$                             # Opening bracket without closing bracket or quotes
-      |
-      ^\\s*(else\\s+)?if\\s*\\([^\\)]+\\)\\s*(//.*)?$  # single-line if/else if (change to indentNextLinePattern when available)
-      |
-      ^\\s*else\\s*(//.*)?$                            # single-line else (change to indentNextLinePattern when available)
-    '''
-    'decreaseIndentPattern': '^(.*\\*/)?\\s*}'
+    'increaseIndentPattern': '^.*\\{(\\}|[^}"\']*)$|^\\s*(public|private|protected):\\s*$'
+    'decreaseIndentPattern': '^(.*\\*/)?\\s*\\}|^\\s*(public|private|protected):\\s*$'
 '.text.html.jsp':
   'editor':
     'foldEndPattern': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
Reverts atom/language-java#82

This _always_ indented the next line even when you added braces.