### PR TITLE
Tokenize new statements in ternaries

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -157,7 +157,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\)|,)'
+    'end': '(?=;|\\)|,|:)'
     'patterns': [
       {
         'include': '#function-call'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -975,6 +975,17 @@ describe 'Java grammar', ->
     expect(tokens[14]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
     expect(tokens[15]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
+    {tokens} = grammar.tokenizeLine 'Point point = true ? new Point(1, 4) : new Point(0, 0);'
+
+    expect(tokens[8]).toEqual value: '?', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.ternary.java']
+    expect(tokens[10]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[12]).toEqual value: 'Point', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[13]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[20]).toEqual value: ':', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.ternary.java']
+    expect(tokens[22]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[31]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
+
     {tokens} = grammar.tokenizeLine 'map.put(key, new Value(value), "extra");'
 
     expect(tokens[12]).toEqual value: ')', scopes: ['source.java', 'meta.method-call.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Stop tokenizing a new statement when encountering a ternary.

### Alternate Designs

None.

### Benefits

New statements in ternary expressions will be tokenized correctly.

### Possible Drawbacks

None

### Applicable Issues

Fixes #85