### PR TITLE
Added java 8 default keyword support

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1126,7 +1126,7 @@
       }
     ]
   'storage-modifiers':
-    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile)\\b'
+    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default)\\b'
     'name': 'storage.modifier.java'
   'strings':
     'patterns': [


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added "default" keyword support for methods. This keyword was added as part of the storage modifiers.

### Alternate Designs

None.

### Benefits

Default keyword on methods are now highlighted 

### Possible Drawbacks

None.

### Applicable Issues

Fixes #71 
