### PR TITLE
Added strictfp keyword as storage modifier

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1126,7 +1126,7 @@
       }
     ]
   'storage-modifiers':
-    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default)\\b'
+    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp)\\b'
     'name': 'storage.modifier.java'
   'strings':
     'patterns': [


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added strictfp keyword as an storage modifier

### Alternate Designs

None

### Benefits

Strictfp keyword is now recognized and highlighted 

### Possible Drawbacks

None.

### Applicable Issues

Fixes #90 