### PR TITLE
Stop new constructor when declared inside block (array)

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -157,7 +157,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\)|,|:|\\})' # close when '}' to interpret ';' correctly for arrays and blocks
+    'end': '(?=;|\\)|,|:|}|\\+)'
     'patterns': [
       {
         'include': '#function-call'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -157,7 +157,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\)|,|:)'
+    'end': '(?=;|\\)|,|:|\\})' # close when '}' to interpret ';' correctly for arrays and blocks
     'patterns': [
       {
         'include': '#function-call'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -991,6 +991,12 @@ describe 'Java grammar', ->
     expect(tokens[21]).toEqual value: '}', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.section.block.end.bracket.curly.java']
     expect(tokens[22]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
+    {tokens} = grammar.tokenizeLine 'String a = (valid ? new Date().toString() + " : " : "");'
+    expect(tokens[23]).toEqual value: ' : ', scopes: ['source.java', 'meta.definition.variable.java', 'string.quoted.double.java']
+    expect(tokens[26]).toEqual value: ':', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.ternary.java']
+    expect(tokens[28]).toEqual value: '"', scopes: ['source.java', 'meta.definition.variable.java', 'string.quoted.double.java', 'punctuation.definition.string.begin.java']
+    expect(tokens[29]).toEqual value: '"', scopes: ['source.java', 'meta.definition.variable.java', 'string.quoted.double.java', 'punctuation.definition.string.end.java']
+
     {tokens} = grammar.tokenizeLine 'String[] list = new String[variable];'
 
     expect(tokens[12]).toEqual value: 'variable', scopes: ['source.java', 'meta.definition.variable.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -964,6 +964,7 @@ describe 'Java grammar', ->
     expect(tokens[28]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
     {tokens} = grammar.tokenizeLine 'A[] arr = new A[]{new A(), new A()};'
+
     expect(tokens[8]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
     expect(tokens[10]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.object.array.java']
     expect(tokens[13]).toEqual value: '{', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.curly.java']
@@ -979,6 +980,7 @@ describe 'Java grammar', ->
     expect(tokens[27]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
     {tokens} = grammar.tokenizeLine 'A[] arr = {new A(), new A()};'
+
     expect(tokens[8]).toEqual value: '{', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.section.block.begin.bracket.curly.java']
     expect(tokens[9]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
     expect(tokens[11]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
@@ -992,6 +994,11 @@ describe 'Java grammar', ->
     expect(tokens[22]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
     {tokens} = grammar.tokenizeLine 'String a = (valid ? new Date().toString() + " : " : "");'
+
+    expect(tokens[16]).toEqual value: 'toString', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[17]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[20]).toEqual value: '+', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.operator.arithmetic.java']
     expect(tokens[23]).toEqual value: ' : ', scopes: ['source.java', 'meta.definition.variable.java', 'string.quoted.double.java']
     expect(tokens[26]).toEqual value: ':', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.ternary.java']
     expect(tokens[28]).toEqual value: '"', scopes: ['source.java', 'meta.definition.variable.java', 'string.quoted.double.java', 'punctuation.definition.string.begin.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -963,6 +963,34 @@ describe 'Java grammar', ->
     expect(tokens[27]).toEqual value: '}', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.curly.java']
     expect(tokens[28]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
+    {tokens} = grammar.tokenizeLine 'A[] arr = new A[]{new A(), new A()};'
+    expect(tokens[8]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[10]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.object.array.java']
+    expect(tokens[13]).toEqual value: '{', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.curly.java']
+    expect(tokens[14]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[16]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[17]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[21]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[23]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[24]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[25]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[26]).toEqual value: '}', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.bracket.curly.java']
+    expect(tokens[27]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
+
+    {tokens} = grammar.tokenizeLine 'A[] arr = {new A(), new A()};'
+    expect(tokens[8]).toEqual value: '{', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.section.block.begin.bracket.curly.java']
+    expect(tokens[9]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[11]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[12]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[13]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[16]).toEqual value: 'new', scopes: ['source.java', 'meta.definition.variable.java', 'keyword.control.new.java']
+    expect(tokens[18]).toEqual value: 'A', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'entity.name.function.java']
+    expect(tokens[19]).toEqual value: '(', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(tokens[20]).toEqual value: ')', scopes: ['source.java', 'meta.definition.variable.java', 'meta.function-call.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(tokens[21]).toEqual value: '}', scopes: ['source.java', 'meta.definition.variable.java', 'punctuation.section.block.end.bracket.curly.java']
+    expect(tokens[22]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
+
     {tokens} = grammar.tokenizeLine 'String[] list = new String[variable];'
 
     expect(tokens[12]).toEqual value: 'variable', scopes: ['source.java', 'meta.definition.variable.java']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR attempts to fix reported #97 issue, when `new` keyword inside the array declaration would not stop after `}` and highlight `;` as part of variable definition (and also invisible characters such as EOL if they are enabled in editor.

```java
A[] arr = new A[] {new A(), new A()};
```

It looks like this behaviour is controlled by `;`, `)`, `,`, `:` characters, for example when having `,` after the last item highlights everything correctly:
```
A[] arr = new A[] { new A(), new A(),};
```

Current solution is simply adding `}` to the list of such characters so we can close constructor correctly. Tested manually and with unit tests (none of existing unit tests failed). Also tested with blocks and when syntax is not properly closed, such as:
```
static {
  new A();
  new A() };
```

This invalid syntax produces the same html as before this patch. Correct syntax works, naturally:)

#### Before fix
<img width="282" alt="before-fix" src="https://cloud.githubusercontent.com/assets/7788766/26748229/f7f9d8c8-484f-11e7-9810-81eae11fb891.png">

#### After fix
<img width="293" alt="after-fix" src="https://cloud.githubusercontent.com/assets/7788766/26748233/ff8a9d98-484f-11e7-9931-c5d1f15f9186.png">

#### HTML for `A[] arr = new A[]{ new A(), new A()};` before fix
Note that at the end it does not mark `}` as bracket and marks `;` and EOL as part of `meta.definition.variable.java`.
```html
<span class="syntax--meta syntax--definition syntax--variable syntax--java">
  <span class="syntax--storage syntax--type syntax--object syntax--array syntax--java">A</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">[</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">]</span> 
  <span class="syntax--variable syntax--other syntax--definition syntax--java">arr</span> 
  <span class="syntax--keyword syntax--operator syntax--assignment syntax--java">=</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--storage syntax--type syntax--object syntax--array syntax--java">A</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">[</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">]</span>
  <span class="syntax--punctuation syntax--bracket syntax--curly syntax--java">{</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--meta syntax--function-call syntax--java">
    <span class="syntax--entity syntax--name syntax--function syntax--java">A</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--begin syntax--bracket syntax--round syntax--java">(</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--end syntax--bracket syntax--round syntax--java">)</span>
  </span>
  <span class="syntax--punctuation syntax--separator syntax--delimiter syntax--java">,</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--meta syntax--function-call syntax--java">
    <span class="syntax--entity syntax--name syntax--function syntax--java">A</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--begin syntax--bracket syntax--round syntax--java">(</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--end syntax--bracket syntax--round syntax--java">)</span>
  </span>
  }
  <span class="syntax--punctuation syntax--terminator syntax--java">;</span>
  <span class="invisible-character eol">¬</span>
</span>
```

#### HTML for `A[] arr = new A[]{ new A(), new A()};` after fix
Note that this correctly excludes `;` and EOL from `meta.definition.variable.java`.
```html
<span class="syntax--meta syntax--definition syntax--variable syntax--java">
  <span class="syntax--storage syntax--type syntax--object syntax--array syntax--java">A</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">[</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">]</span> 
  <span class="syntax--variable syntax--other syntax--definition syntax--java">arr</span> 
  <span class="syntax--keyword syntax--operator syntax--assignment syntax--java">=</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--storage syntax--type syntax--object syntax--array syntax--java">A</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">[</span>
  <span class="syntax--punctuation syntax--bracket syntax--square syntax--java">]</span>
  <span class="syntax--punctuation syntax--bracket syntax--curly syntax--java">{</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--meta syntax--function-call syntax--java">
    <span class="syntax--entity syntax--name syntax--function syntax--java">A</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--begin syntax--bracket syntax--round syntax--java">(</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--end syntax--bracket syntax--round syntax--java">)</span>
  </span>
  <span class="syntax--punctuation syntax--separator syntax--delimiter syntax--java">,</span> 
  <span class="syntax--keyword syntax--control syntax--new syntax--java">new</span> 
  <span class="syntax--meta syntax--function-call syntax--java">
    <span class="syntax--entity syntax--name syntax--function syntax--java">A</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--begin syntax--bracket syntax--round syntax--java">(</span>
    <span class="syntax--punctuation syntax--definition syntax--parameters syntax--end syntax--bracket syntax--round syntax--java">)</span>
  </span>
  <span class="syntax--punctuation syntax--bracket syntax--curly syntax--java">}</span>
</span>
```

### Alternate Designs
None were considered, unfortunately.

### Benefits
Fairly simple change that sort of seems logical to add.

### Possible Drawbacks
Might potentially break other unknown at the time cases.

### Applicable Issues
None I am aware of.
