### PR TITLE
Optimize variable matching

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1178,19 +1178,23 @@
       }
     ]
   'variables':
-    'begin': '''
-      (?x:(?=
+    'begin': '''(?x)
+      (?=
         (
           (void|boolean|byte|char|short|int|float|long|double)
           |
-          ((\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
+          (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
-        ([\\w<>\\[\\],][\\w<>\\[\\],?\\s]*)?
+        (
+          <[\\w<>,?\\s]*> # HashMap<Integer, String>
+          |
+          (\\[\\])* # int[][]
+        )?
         \\s+
         [A-Za-z_$][\\w$]* # At least one identifier after space
         ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers
         \\s*(=|;)
-      ))
+      )
     '''
     'end': '(?=;)'
     'name': 'meta.definition.variable.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -216,6 +216,21 @@ describe 'Java grammar', ->
     expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
     expect(lines[6][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
 
+  it 'does not catastrophically backtrack when tokenizing large enums (regression)', ->
+    # https://github.com/atom/language-java/issues/103
+    # This test 'fails' if it runs for an absurdly long time without completing.
+    # It should pass almost immediately just like all the other tests.
+
+    enumContents = 'AAAAAAAAAAA, BBBBBBBBBB, CCCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE, FFFFFFFFFF, '.repeat(50)
+
+    lines = grammar.tokenizeLines """
+      public enum test {
+        #{enumContents}
+      }
+    """
+
+    expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
+
   it 'tokenizes methods', ->
     lines = grammar.tokenizeLines '''
       class A


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Introduces two optimizations to variable matching.

1. Make the storage type group atomic to prevent useless backtracking.  This sped up tokenization time by about 100% for me (~26ms) when testing on regex101.com (https://regex101.com/r/gXSE7p/1).
2. Instead of throwing a jumble of characters and saying "hey, if one of these matches, maybe you can form a coherent match out of them?" make the match coherent to begin with.  This was the main cause of the catastrophic backtracking because of the inclusion of *both* `,` and `\s` in the character class.

### Alternate Designs

I debated attempting a rewrite of the `begin` pattern, but I think this will suffice for now.

### Benefits

When given a large single-line enum, Atom should no longer hang.

### Possible Drawbacks

It may be non-apparent when the new regression test fails on CI, because it'll most likely timeout the build itself rather than actually failing.

### Applicable Issues

Fixes #103