### PR TITLE
Fix issue when tokenizing an empty comment

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -477,7 +477,7 @@
     ]
   'comments-javadoc':
     'patterns': [
-      'begin': '^\\s*/\\*\\*'
+      'begin': '^\\s*/\\*\\*(?!/)'
       'beginCaptures':
         '0':
           'name': 'punctuation.definition.comment.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1582,6 +1582,39 @@ describe 'Java grammar', ->
     expect(lines[5][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
     expect(lines[5][2]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
+  it 'tokenizes empty/single character comment', ->
+    # this test checks the correct tokenizing of empty/single character comments
+    # comment like /**/ should be parsed as single line comment, but /***/ should be parsed as javadoc
+    lines = grammar.tokenizeLines '''
+      /**/ int a = 1;
+      /**/ int b = 1;
+      /**/ int c = 1;
+      /**/ int d = 1;
+
+      /***/ int e = 1;
+      /**/ int f = 1;
+      /** */ int g = 1;
+      /* */ int h = 1;
+      '''
+
+    expect(lines[0][0]).toEqual value: '/**/', scopes: ['source.java', 'comment.block.empty.java', 'punctuation.definition.comment.java']
+    expect(lines[0][2]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[1][0]).toEqual value: '/**/', scopes: ['source.java', 'comment.block.empty.java', 'punctuation.definition.comment.java']
+    expect(lines[1][2]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[2][0]).toEqual value: '/**/', scopes: ['source.java', 'comment.block.empty.java', 'punctuation.definition.comment.java']
+    expect(lines[2][2]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[3][0]).toEqual value: '/**/', scopes: ['source.java', 'comment.block.empty.java', 'punctuation.definition.comment.java']
+    expect(lines[3][2]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+
+    expect(lines[5][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[5][1]).toEqual value: '*/', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[6][0]).toEqual value: '/**/', scopes: ['source.java', 'comment.block.empty.java', 'punctuation.definition.comment.java']
+    expect(lines[6][2]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[7][0]).toEqual value: '/**', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[7][2]).toEqual value: '*/', scopes: ['source.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[8][0]).toEqual value: '/*', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+    expect(lines[8][2]).toEqual value: '*/', scopes: ['source.java', 'comment.block.java', 'punctuation.definition.comment.java']
+
   it 'tokenizes inline comment inside method signature', ->
     # this checks usage of inline /*...*/ comments mixing with parameters
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue raised in #120. When writing something like this:
```java
/**/ int a = 1;
```
Code highlights the entire line as comment. This happens because the entire line is treated as a beginning of javadoc comment that starts with `/**`, and since it is allowed to be multiline, it affects following lines. This situation should be highlighted as empty comment, which we already have in spec. 

Patch uses pattern `'begin': '^\\s*/\\*\\*(?!/)'` for javadoc comment, so we exclude the immediately following `/`. This means that `/**/` is treated as empty comment, `/***/` is treated as javadoc. All other situations `/** /`, `/*/` are unclosed comments and invalid.

### Alternate Designs
None were considered, it looks like this fix is reasonably sound.

### Benefits
Fixes current bug with highlighting empty comments.

### Possible Drawbacks
None that I am aware of.

### Applicable Issues
Fixes #120