### PR TITLE
Add comments into catch parameters block

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -588,6 +588,9 @@
             'contentName': 'meta.catch.parameters.java'
             'patterns': [
               {
+                'include': '#comments'
+              }
+              {
                 'include': '#parameters'
               }
             ]

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1549,6 +1549,27 @@ describe 'Java grammar', ->
     expect(lines[5][1]).toEqual value: '//', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java']
     expect(lines[5][2]).toEqual value: ' single-line comment', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'comment.line.double-slash.java']
 
+  it 'tokenizes comment inside try-catch-finally block', ->
+    lines = grammar.tokenizeLines '''
+      try {
+        // comment A
+      } catch (IOException /* RuntimeException */ err) {
+        // comment B
+      } finally {
+        // comment C
+      }
+      '''
+
+    expect(lines[1][1]).toEqual value: '//', scopes: ['source.java', 'meta.try.java', 'meta.try.body.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java']
+    expect(lines[1][2]).toEqual value: ' comment A', scopes: ['source.java', 'meta.try.java', 'meta.try.body.java', 'comment.line.double-slash.java']
+    expect(lines[2][7]).toEqual value: '/*', scopes: ['source.java', 'meta.catch.java', 'meta.catch.parameters.java', 'comment.block.java', 'punctuation.definition.comment.java']
+    expect(lines[2][8]).toEqual value: ' RuntimeException ', scopes: ['source.java', 'meta.catch.java', 'meta.catch.parameters.java', 'comment.block.java']
+    expect(lines[2][9]).toEqual value: '*/', scopes: ['source.java', 'meta.catch.java', 'meta.catch.parameters.java', 'comment.block.java', 'punctuation.definition.comment.java']
+    expect(lines[3][1]).toEqual value: '//', scopes: ['source.java', 'meta.catch.java', 'meta.catch.body.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java']
+    expect(lines[3][2]).toEqual value: ' comment B', scopes: ['source.java', 'meta.catch.java', 'meta.catch.body.java', 'comment.line.double-slash.java']
+    expect(lines[5][1]).toEqual value: '//', scopes: ['source.java', 'meta.finally.java', 'meta.finally.body.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java']
+    expect(lines[5][2]).toEqual value: ' comment C', scopes: ['source.java', 'meta.finally.java', 'meta.finally.body.java', 'comment.line.double-slash.java']
+
   it 'tokenizes single-line javadoc comment', ->
     lines = grammar.tokenizeLines '''
       /** single-line javadoc comment */


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue of missing comments highlighting in `catch` parameters block. For example,
```java
try {
  ...
} catch (IOException /* RuntimeException */ err) {
  ...
}
```

RuntimeException would not be highlighted correctly as comment, this PR fixes it.
The only change is including `#comments` pattern into `meta.catch.parameters.java`.

I added test to make sure that comments in try-catch-finally block are rendered. Note that we still **do not support** something like this:
```java
try {
  ...
} catch /* unsupported comment */ (Exception err) {
  ...
} finally /* unsupported comment */ {
  ...
}
```

I simply do not know how to fix it easily. Would appreciate if someone could help with this (if it needs to be fixed).

### Alternate Designs
None were considered because of the simplicity of the fix.

### Benefits
Fixes comment highlighting in catch parameters block.

### Possible Drawbacks
Might break something else. 

### Applicable Issues
Issue #114 (issue is created for a different bug, but this problem was raised in the comments).
