### PR TITLE
Fix variable assignment in try-with-resources pattern

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1237,7 +1237,7 @@
           (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
         (
-          <[\\w<>,?\\s]*> # HashMap<Integer, String>
+          <[\\w<>,\\.?\\s]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`
         )?
         (
           (\\[\\])* # int[][]

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -545,7 +545,7 @@
             'name': 'meta.try.resources.java'
             'patterns': [
               {
-                'include': '#variables-definition-only'
+                'include': '#variable-assignment'
               }
               {
                 'include': '#code'
@@ -1207,15 +1207,14 @@
       }
     ]
   # pattern for variable name
-  'variables-name':
+  'variable-name':
     'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
     'captures':
       '1':
         'name': 'variable.other.definition.java'
-  # pattern for definition of a variable including assignment, but without expression part, e.g.
-  # 'String variable =' or 'int num =', used with '#code' when we cannot rely on ';' to terminate
-  # variable assignment
-  'variables-definition-only':
+  # pattern for a variable assignment (without expression part), e.g. 'String variable =' or
+  # 'int num =', used in places where we cannot rely on ';' as a terminating character for a match
+  'variable-assignment':
     'begin': '''(?x)
       (?=
         (
@@ -1239,20 +1238,21 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'include': '#variables-name'
+        'include': '#variable-name'
       }
       {
         'include': '#all-types'
       }
       {
-        'match': '='
-        'captures':
+        'begin': '='
+        'beginCaptures':
           '0':
             'name': 'keyword.operator.assignment.java'
+        'end': '(?!\\G)'
       }
     ]
-  # pattern for full variable assignment
-  # when updating pattern make sure it is in sync with '#variables-definition-only' pattern
+  # pattern for full variable definition
+  # when updating pattern make sure it is in sync with '#variable-assignment' pattern
   'variables':
     'begin': '''(?x)
       (?=
@@ -1277,7 +1277,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'include': '#variables-name'
+        'include': '#variable-name'
       }
       {
         'include': '#all-types'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -545,6 +545,9 @@
             'name': 'meta.try.resources.java'
             'patterns': [
               {
+                'include': '#variables-definition-only'
+              }
+              {
                 'include': '#code'
               }
             ]
@@ -1203,6 +1206,53 @@
         'include': '#object-types'
       }
     ]
+  # pattern for variable name
+  'variables-name':
+    'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
+    'captures':
+      '1':
+        'name': 'variable.other.definition.java'
+  # pattern for definition of a variable including assignment, but without expression part, e.g.
+  # 'String variable =' or 'int num =', used with '#code' when we cannot rely on ';' to terminate
+  # variable assignment
+  'variables-definition-only':
+    'begin': '''(?x)
+      (?=
+        (
+          (void|boolean|byte|char|short|int|float|long|double)
+          |
+          (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
+        )
+        (
+          <[\\w<>,?\\s]*> # HashMap<Integer, String>
+        )?
+        (
+          (\\[\\])* # int[][]
+        )?
+        \\s+
+        [A-Za-z_$][\\w$]* # At least one identifier after space
+        ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers
+        \\s*(=)
+      )
+    '''
+    'end': '(?=\\=)'
+    'name': 'meta.definition.variable.java'
+    'patterns': [
+      {
+        'include': '#variables-name'
+      }
+      {
+        'include': '#all-types'
+      }
+      {
+        'match': '='
+        'captures':
+          '0':
+            'name': 'keyword.operator.assignment.java'
+      }
+    ]
+  # pattern for full variable assignment
+  # when updating pattern make sure it is in sync with '#variables-definition-only' pattern
   'variables':
     'begin': '''(?x)
       (?=
@@ -1227,10 +1277,7 @@
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
-        'captures':
-          '1':
-            'name': 'variable.other.definition.java'
+        'include': '#variables-name'
       }
       {
         'include': '#all-types'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1249,7 +1249,7 @@
         \\s+
         [A-Za-z_$][\\w$]* # At least one identifier after space
         ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers
-        \\s*(=)
+        \\s*(=) # this should not contain ';'
       )
     '''
     'end': '(?=\\=)'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1510,6 +1510,7 @@ describe 'Java grammar', ->
         private void fn() {
           try (
             BufferedReader in = new BufferedReader();
+            BufferedReader br = new BufferedReader(new FileReader(path))
           ) {
             // stuff
           }
@@ -1522,9 +1523,10 @@ describe 'Java grammar', ->
     expect(lines[2][2]).toEqual value: ' ', scopes: scopes
     expect(lines[2][3]).toEqual value: '(', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.begin.bracket.round.java']
     expect(lines[3][1]).toEqual value: 'BufferedReader', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[4][1]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
-    expect(lines[4][2]).toEqual value: ' ', scopes: scopes
-    expect(lines[4][3]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
+    expect(lines[4][1]).toEqual value: 'BufferedReader', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[5][1]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
+    expect(lines[5][2]).toEqual value: ' ', scopes: scopes
+    expect(lines[5][3]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
 
   it 'tokenizes comment inside method body', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1598,6 +1598,31 @@ describe 'Java grammar', ->
     expect(lines[5][2]).toEqual value: ' ', scopes: scopes
     expect(lines[5][3]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
 
+  it 'tokenizes generics with dots in try-catch with resources', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        void func() {
+          try (List<java.lang.String> a = get()) {
+            // do something
+          }
+        }
+      }
+    '''
+
+    scopes = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.try.java']
+    expect(lines[2][1]).toEqual value: 'try', scopes: scopes.concat ['keyword.control.try.java']
+    expect(lines[2][3]).toEqual value: '(', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.begin.bracket.round.java']
+    expect(lines[2][4]).toEqual value: 'List', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][5]).toEqual value: '<', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][6]).toEqual value: 'java', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][7]).toEqual value: '.', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][8]).toEqual value: 'lang', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][9]).toEqual value: '.', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][10]).toEqual value: 'String', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][11]).toEqual value: '>', scopes: scopes.concat ['meta.try.resources.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][20]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
+    expect(lines[2][22]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
+
   it 'tokenizes comment inside method body', ->
     lines = grammar.tokenizeLines '''
       class Test


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue with broken highlighting when resource expression is not closed with `;` in try-with-resources pattern, which is technically allowed. @50Wliu suggested to come up with separate pattern for try-with-resources, which I simplified a bit by keeping original try-catch-finally, but instead creating separate pattern for variable definition. 

Such pattern is called `variables-definition-only` and used in try-with-resources to match the following: `String variable =` or `int num =` without actual expression. We use `#code` in patterns to highlight the expression code. 

In this case `meta.definition.variable.java` only covers type, variable name and `=`. I am not sure if this is required to add code, but it highlights correctly.

After patch (also passes test case mentioned in the issue):
<img width="294" alt="after-patch" src="https://user-images.githubusercontent.com/7788766/35179953-3043e56e-fe0a-11e7-8757-98f06bc0ddf2.png">

### Alternate Designs
Alternative design was considered where we apply a hack to `end` by listing `)` as another terminating character. This is a very small fix (4-8 characters change), but could potentially result in other issues, such as triggering close on closing paren (see https://github.com/atom/language-java/issues/88#issuecomment-333003571).

### Benefits
Fixes issue where not using `;` (which is allowed by specification) would break the highlighting. This change is relatively minor and only affects `try-with-resources`.

### Possible Drawbacks
Since we have to duplicate large regular expression to capture variables (in `variables` and `variables-definition-only`), this could potentially result in updating only one but not the other. I added comment that both patterns should be updated and be in sync, but this might be enough.

### Applicable Issues
Fixes #88
