### PR TITLE
Fix unified expression language single quote escape

### DIFF
--- a/grammars/unified expression language (el).cson
+++ b/grammars/unified expression language (el).cson
@@ -57,7 +57,7 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.java.el'
-    'end': '\''
+    'end': '(?<!\\\\)\''
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.java.el'

--- a/spec/unified-el-spec.coffee
+++ b/spec/unified-el-spec.coffee
@@ -157,6 +157,14 @@ describe 'Unified expression language grammar', ->
       expect(tokens[5]).toEqual value: 'baz', scopes: ['source.java.el', 'string.quoted.single.java.el']
       expect(tokens[6]).toEqual value: "'", scopes: ['source.java.el', 'string.quoted.single.java.el', 'punctuation.definition.string.end.java.el']
 
+    it 'tokenizes single quoted string literals with escaped single quote', ->
+      {tokens} = grammar.tokenizeLine "'foo \\\\\' bar'"
+      expect(tokens[0]).toEqual value: "'", scopes: ['source.java.el', 'string.quoted.single.java.el', 'punctuation.definition.string.begin.java.el']
+      expect(tokens[1]).toEqual value: 'foo ', scopes: ['source.java.el', 'string.quoted.single.java.el']
+      expect(tokens[2]).toEqual value: '\\\\', scopes: ['source.java.el', 'string.quoted.single.java.el', 'constant.character.escape.java.el']
+      expect(tokens[3]).toEqual value: '\' bar', scopes: ['source.java.el', 'string.quoted.single.java.el']
+      expect(tokens[4]).toEqual value: "'", scopes: ['source.java.el', 'string.quoted.single.java.el', 'punctuation.definition.string.end.java.el']
+
     it 'tokenizes double quoted string literals', ->
       {tokens} = grammar.tokenizeLine '"foo\\n bar \\\"baz"'
       expect(tokens[0]).toEqual value: '"', scopes: ['source.java.el', 'string.quoted.double.java.el', 'punctuation.definition.string.begin.java.el']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue when escaping single quote in single quoted string affects subsequent highlighting, because current pattern matches the first single quote as the end of the literal, even though it is escaped. It was realised that we only need to match ending of literal when it is not escaped, any single quote with preceding '\\' should be marked as escaped.

Before patch:
<img width="500" alt="before-patch" src="https://user-images.githubusercontent.com/7788766/35191048-179a1002-fed6-11e7-88b0-3512255668ad.png">

After patch:
<img width="495" alt="after-patch" src="https://user-images.githubusercontent.com/7788766/35191049-1ddaa09e-fed6-11e7-8928-668bfd023065.png">

Also correctly highlights situation `'\\   '`, though I am not sure if this is a correct syntax. 

### Alternate Designs
None were considered apart from the PR solution.

### Benefits
Fixes issue of highlighting when escaping single quote in single quote string literal.

### Possible Drawbacks
Might break some other code, because I am not very familiar with expression language and could have overlooked some escape situations, such as using the `\\'` as a value.

### Applicable Issues
Fixes #83
