### PR TITLE
Fix capitalized variables being highlighted as storage type

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1003,8 +1003,9 @@
         ]
       }
       {
-        # If the above fails *then* just look for Wow (must be followed by a variable name)
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b(?=\\s*(\\w|\\$))'
+        # If the above fails *then* just look for Wow
+        # (must be followed by a variable name, we use '\n' to cover multi-line definitions)
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b(?=\\s*[A-Za-z$_\\n])'
         'name': 'storage.type.java'
         'captures':
           '1':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1003,8 +1003,8 @@
         ]
       }
       {
-        # If the above fails *then* just look for Wow
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b'
+        # If the above fails *then* just look for Wow (must be followed by a variable name)
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b(?=\\s*(\\w|\\$))'
         'name': 'storage.type.java'
         'captures':
           '1':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -770,6 +770,30 @@ describe 'Java grammar', ->
     expect(lines[6][3]).toEqual value: 'primitive', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
     expect(lines[6][7]).toEqual value: '5', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.definition.variable.java', 'constant.numeric.decimal.java']
 
+  it 'tokenizes capitalized variables', ->
+    lines = grammar.tokenizeLines '''
+      void func()
+      {
+        int g = 1;
+        g += 2;
+        int G = 1;
+        G += 2;
+
+        if (G > g) {
+          // do something
+        }
+      }
+    '''
+
+    expect(lines[2][3]).toEqual value: 'g', scopes: ['source.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[3][0]).toEqual value: '  g ', scopes: ['source.java']
+    expect(lines[4][3]).toEqual value: 'G', scopes: ['source.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[5][0]).toEqual value: '  G ', scopes: ['source.java'] # should not be highlighted as storage type!
+
+    expect(lines[7][4]).toEqual value: 'G ', scopes: ['source.java'] # should not be highlighted as storage type!
+    expect(lines[7][5]).toEqual value: '>', scopes: ['source.java', 'keyword.operator.comparison.java']
+    expect(lines[7][6]).toEqual value: ' g', scopes: ['source.java']
+
   it 'tokenizes function and method calls', ->
     lines = grammar.tokenizeLines '''
       class A


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes highlighting of variables that are capitalized or start with capital letter. I fixed by enforcing that the last branch of 'object-types' pattern requires the next word (variable name); and since variable names can start with `A-Za-z` or `_`, or `$`, I added `\w|$`.

Tested on the code:
```java
class A {
  void func() {
    int g = 1;
    g += 2;
    int G = 1;
    G += 2;
    ABC += 3;
    Abc += 4;

    if (G > g) {
      // do something
      String a = "abc";
    }
  }
}
```

### Alternate Designs
None were considered, though I was experimenting with different changes to see what actually affects the highlighting. 

### Benefits
Fix problem with highlighting variables starting with capital letters in situations like, but not limited to:
```java
A += 2;
A = 3;
if (A > B) {
  // something
}
```

### Possible Drawbacks
Might break something else, but it passes all tests so far.

### Applicable Issues
Closes #76
