### PR TITLE
Add varargs scope

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1057,7 +1057,7 @@
       },
       {
         'match': '\\.\\.\\.'
-        'name': 'punctuation.definition.parameters.varargs'
+        'name': 'punctuation.definition.parameters.varargs.java'
       }
     ]
   'parens':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1054,6 +1054,10 @@
       {
         'match': ','
         'name': 'punctuation.separator.delimiter.java'
+      },
+      {
+        'match': '\\.\\.\\.'
+        'name': 'punctuation.definition.parameters.varargs'
       }
     ]
   'parens':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -250,6 +250,26 @@ describe 'Java grammar', ->
     expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
     expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
 
+  it 'tokenizes variable-length argument list (varargs)', ->
+    lines = grammar.tokenizeLines '''
+      class A
+      {
+        void func1(String... args)
+        {
+        }
+
+        void func2(int /* ... */ arg, int ... args)
+        {
+        }
+      }
+    '''
+    expect(lines[2][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.java']
+    expect(lines[2][6]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs']
+    expect(lines[6][5]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.java']
+    expect(lines[6][8]).toEqual value: ' ... ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'comment.block.java']
+    expect(lines[6][14]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.java']
+    expect(lines[6][16]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs']
+
   it 'tokenizes `final` in class method', ->
     lines = grammar.tokenizeLines '''
       class A

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -264,11 +264,11 @@ describe 'Java grammar', ->
       }
     '''
     expect(lines[2][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.java']
-    expect(lines[2][6]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs']
+    expect(lines[2][6]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs.java']
     expect(lines[6][5]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.java']
     expect(lines[6][8]).toEqual value: ' ... ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'comment.block.java']
     expect(lines[6][14]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.java']
-    expect(lines[6][16]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs']
+    expect(lines[6][16]).toEqual value: '...', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.varargs.java']
 
   it 'tokenizes `final` in class method', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR adds new scope for variable length arguments list denoted as `...`, for example,
```java
void func(String ... args) {
  // code
}
```
Name of the scope is `punctuation.definition.parameters.varargs` and it is added to the `parameters` list of patterns. 

Tested manually on different code snippets and added unittest.

### Alternate Designs
None were considered, since the change is fairly straightforward. I did change scope name for this to 
`punctuation.definition.parameters.varargs.java`.

### Benefits
Adds new scope for varargs.

### Possible Drawbacks
Should not be any, change is fairly minor and only affects parameters list for functions and methods.

### Applicable Issues
Closes #129 
