### PR TITLE
Fix highlighting for generics with dots in class name

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -697,6 +697,10 @@
         'name': 'punctuation.separator.delimiter.java'
       }
       {
+        'match': '\\.'
+        'name': 'punctuation.separator.period.java'
+      }
+      {
         'include': '#parens'
       }
       {
@@ -1216,7 +1220,7 @@
           (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
         (
-          <[\\w<>,?\\s]*> # HashMap<Integer, String>
+          <[\\w<>,\\.?\\s]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`
         )?
         (
           (\\[\\])* # int[][]

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -672,7 +672,7 @@
         'name': 'storage.modifier.$1.java'
       }
       {
-        'match': '([a-zA-Z$_][a-zA-Z0-9$_]*)(?=\\s*<)'
+        'match': '(?<!\\.)([a-zA-Z$_][a-zA-Z0-9$_]*)(?=\\s*<)'
         'captures':
           '1':
             'name': 'storage.type.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -873,6 +873,8 @@ describe 'Java grammar', ->
         C(Map<?, ? extends List<?>> m) {}
         Map<Integer, String> method() {}
         private Object otherMethod() { return null; }
+        Set<Map.Entry<K, V>> set1;
+        Set<java.util.List<K>> set2;
       }
     '''
 
@@ -933,6 +935,30 @@ describe 'Java grammar', ->
     expect(lines[6][1]).toEqual value: 'private', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'storage.modifier.java']
     expect(lines[6][3]).toEqual value: 'Object', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.java']
     expect(lines[6][5]).toEqual value: 'otherMethod', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[7][1]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[7][2]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[7][3]).toEqual value: 'Map', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[7][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[7][5]).toEqual value: 'Entry', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[7][6]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[7][7]).toEqual value: 'K', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[7][8]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.delimiter.java']
+    expect(lines[7][10]).toEqual value: 'V', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[7][11]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[7][12]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[7][14]).toEqual value: 'set1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[8][1]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[8][2]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][3]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[8][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[8][5]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[8][6]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[8][7]).toEqual value: 'List', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[8][8]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][9]).toEqual value: 'K', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[8][10]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][11]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][13]).toEqual value: 'set2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
   it 'tokenizes generics in if-else code block', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes issue when having code like `Set<java.lang.String> var = ...`, `java.lang.String` part was highlighted incorrectly. 

Consider code below:
```java
class A {
  Set<MapEntry<K, V>> var = null;
  Set<Map.Entry<K, V>> varA = null;
  Set<java.util.List<K>> varB = null;
}
```

#### Before the patch:
<img width="304" alt="before" src="https://user-images.githubusercontent.com/7788766/36966271-1c455186-20c1-11e8-8b9b-0be77cc49996.png">

#### After the patch
<img width="281" alt="after" src="https://user-images.githubusercontent.com/7788766/36966259-19050250-20c1-11e8-9d45-363e1095552b.png">

### Alternate Designs
None were considered. I just tried different combinations of patterns to see which one worked.

### Benefits
Fixes the issue, without breaking existing tests.

### Possible Drawbacks
This does not fix code like following, parts `java.util.Set` and `java.lang.String` are highlighted incorrectly:
```java
class A {
  java.util.Set<java.util.List<K>> varA = null;
  java.lang.String varB = null;
}
```
But I think this is outside of the scope of this PR.

### Applicable Issues
Fixes #131 

