### PR TITLE
Fix master branch: add varargs into object-types pattern

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1008,8 +1008,9 @@
       }
       {
         # If the above fails *then* just look for Wow
-        # (must be followed by a variable name, we use '\n' to cover multi-line definitions)
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b(?=\\s*[A-Za-z$_\\n])'
+        # (must be followed by a variable name, we use '\n' to cover multi-line definitions,
+        # or varargs for function definitions)
+        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))'
         'name': 'storage.type.java'
         'captures':
           '1':


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR fixes master branch. It was broken after I merged varargs -> capitalised variables pull requests.
The reason it started failing is that for capital variables we check if storage type is followed by variable name. This does not work for `...` varargs, e.g. `String ... args`. So I included it in the regexp. Yes, it is not pretty, but fixes tests and I checked manually with different codes.

### Alternate Designs
None, unfortunately, just wanted to fix it. Other ways would be reconsidering how to work with capital variables.

### Benefits
Fixes master branch.

### Possible Drawbacks
The fix makes `object-types` scope messy.

### Applicable Issues
None
