### PR TITLE
Add reserved keywords

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -814,6 +814,10 @@
         'match': '(\\||&)'
         'name': 'keyword.operator.bitwise.java'
       }
+      {
+        'match': '\\b(const|goto)\\b'
+        'name': 'keyword.reserved.java'
+      }
     ]
   'lambda-expression':
     'patterns': [

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -183,6 +183,15 @@ describe 'Java grammar', ->
 
     expect(tokens[3]).toEqual value: '.', scopes: ['source.java', 'meta.import.java', 'storage.modifier.import.java', 'invalid.illegal.character_not_allowed_here.java']
 
+  it 'tokenizes reserved keywords', ->
+    {tokens} = grammar.tokenizeLine 'const value'
+
+    expect(tokens[0]).toEqual value: 'const', scopes: ['source.java', 'keyword.reserved.java']
+
+    {tokens} = grammar.tokenizeLine 'int a = 1; goto;'
+
+    expect(tokens[9]).toEqual value: 'goto', scopes: ['source.java', 'keyword.reserved.java']
+
   it 'tokenizes classes', ->
     lines = grammar.tokenizeLines '''
       class Thing {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR adds reserved keywords `const` and `goto`, so they are highlighted as standard keywords, e.g. `try` or `catch`, or `instanceof`. I assigned scope `keyword.reserved.java` for them, because I could not figure out what existing scope they should belong to, since they are not used:).

Looks like this now:
<img width="180" alt="after" src="https://user-images.githubusercontent.com/7788766/37325910-adbb7044-26f4-11e8-9a14-163c692b6d16.png">

### Alternate Designs
None were considered, because it is fairly simple change.

### Benefits
Reserved keywords are now highlighted the same way as standard keywords.

### Possible Drawbacks
None.

### Applicable Issues
#136 
