### PR TITLE
Add Java 9/10 keywords

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -109,6 +109,9 @@
   {
     'include': '#code'
   }
+  {
+    'include': '#module'
+  }
 ]
 'repository':
   'all-types':
@@ -914,6 +917,39 @@
       }
       {
         'include': '#comments'
+      }
+    ]
+  'module':
+    # a uniquely named, reusable group of related packages, as well as resources (such as images
+    # and XML files).
+    'begin': '((open)\\s)?(module)\\s+(\\w+)'
+    'end': '}'
+    'beginCaptures':
+      '1':
+        'name': 'storage.modifier.java'
+      '3':
+        'name': 'storage.modifier.java'
+      '4':
+        'name': 'entity.name.type.module.java'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.module.end.bracket.curly.java'
+    'name': 'meta.module.java'
+    'patterns': [
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.module.begin.bracket.curly.java'
+        'end': '(?=})'
+        'contentName': 'meta.module.body.java'
+        'patterns': [
+          # TODO: Write more rules for module grammar
+          {
+            'match': '\\b(requires|transitive|exports|opens|to|uses|provides|with)\\b'
+            'name': 'keyword.module.java'
+          }
+        ]
       }
     ]
   'numbers':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -192,6 +192,22 @@ describe 'Java grammar', ->
 
     expect(tokens[9]).toEqual value: 'goto', scopes: ['source.java', 'keyword.reserved.java']
 
+  it 'tokenizes module keywords', ->
+    lines = grammar.tokenizeLines '''
+      module Provider {
+        requires ServiceInterface;
+        provides javax0.serviceinterface.ServiceInterface with javax0.serviceprovider.Provider;
+      }
+    '''
+
+    expect(lines[0][0]).toEqual value: 'module', scopes: ['source.java', 'meta.module.java', 'storage.modifier.java']
+    expect(lines[0][2]).toEqual value: 'Provider', scopes: ['source.java', 'meta.module.java', 'entity.name.type.module.java']
+    expect(lines[0][4]).toEqual value: '{', scopes: ['source.java', 'meta.module.java', 'punctuation.section.module.begin.bracket.curly.java']
+    expect(lines[1][1]).toEqual value: 'requires', scopes: ['source.java', 'meta.module.java', 'meta.module.body.java', 'keyword.module.java']
+    expect(lines[2][1]).toEqual value: 'provides', scopes: ['source.java', 'meta.module.java', 'meta.module.body.java', 'keyword.module.java']
+    expect(lines[2][3]).toEqual value: 'with', scopes: ['source.java', 'meta.module.java', 'meta.module.body.java', 'keyword.module.java']
+    expect(lines[3][0]).toEqual value: '}', scopes: ['source.java', 'meta.module.java', 'punctuation.section.module.end.bracket.curly.java']
+
   it 'tokenizes classes', ->
     lines = grammar.tokenizeLines '''
       class Thing {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
- All new code requires tests to ensure against regressions


## Description of the Change

This PR adds reserved keywords open,module,requires,transitive,exports,opens,to,uses,provides and with, so they are highlighted as standard keywords. I assigned scope keyword.modules.java for them, because they are used in modules-info.java.
See §3.9 in http://cr.openjdk.java.net/~mr/jigsaw/spec/java-se-9-jls-diffs.pdf

Before:
![527a](https://user-images.githubusercontent.com/388609/40681445-65691220-6389-11e8-9c0c-fecb9dc9aae6.png)

After:
![527](https://user-images.githubusercontent.com/388609/40681462-79aed58a-6389-11e8-8791-7f2afa032665.png)

## Alternate Designs

None were considered, because it is fairly simple change.

## Benefits

Java 9/10 keywords are now highlighted the same way as standard keywords.

## Possible Drawbacks

None.

## Applicable Issues

#142
