### PR TITLE
Fix meta.catch.java and meta.throwables.java scopes

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -595,7 +595,16 @@
                 'include': '#comments'
               }
               {
-                'include': '#parameters'
+                'match': '\\|'
+                'name': 'punctuation.catch.separator'
+              }
+              {
+                'match': '([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)*'
+                'captures':
+                  '1':
+                    'name': 'storage.type.java'
+                  '2':
+                    'name': 'variable.parameter.java'
               }
             ]
           }
@@ -1218,7 +1227,12 @@
     'name': 'meta.throwables.java'
     'patterns': [
       {
-        'include': '#object-types'
+        'match': ','
+        'name': 'punctuation.throwables.separator'
+      }
+      {
+        'match': '[a-zA-Z$_][\\.a-zA-Z0-9$_]*'
+        'name': 'storage.type.java'
       }
     ]
   'variables':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -596,10 +596,10 @@
               }
               {
                 'match': '\\|'
-                'name': 'punctuation.catch.separator'
+                'name': 'punctuation.catch.separator.java'
               }
               {
-                'match': '([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)*'
+                'match': '([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?'
                 'captures':
                   '1':
                     'name': 'storage.type.java'
@@ -1228,7 +1228,7 @@
     'patterns': [
       {
         'match': ','
-        'name': 'punctuation.throwables.separator'
+        'name': 'punctuation.separator.delimiter.java'
       }
       {
         'match': '[a-zA-Z$_][\\.a-zA-Z0-9$_]*'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1622,7 +1622,7 @@ describe 'Java grammar', ->
     expect(lines[5][3]).toEqual value: 'catch', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'keyword.control.catch.java']
     expect(lines[5][5]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.begin.bracket.round.java']
     expect(lines[5][6]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
-    expect(lines[5][8]).toEqual value: '|', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'punctuation.catch.separator']
+    expect(lines[5][8]).toEqual value: '|', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'punctuation.catch.separator.java']
     expect(lines[5][10]).toEqual value: 'Exception2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
     expect(lines[5][12]).toEqual value: 'err', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'variable.parameter.java']
     expect(lines[5][13]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.end.bracket.round.java']
@@ -1642,7 +1642,7 @@ describe 'Java grammar', ->
 
     expect(lines[1][9]).toEqual value: 'throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.modifier.java']
     expect(lines[1][11]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.type.java']
-    expect(lines[1][12]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'punctuation.throwables.separator']
+    expect(lines[1][12]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'punctuation.separator.delimiter.java']
     expect(lines[1][14]).toEqual value: 'Exception2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.type.java']
     expect(lines[1][16]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
 

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1439,20 +1439,20 @@ describe 'Java grammar', ->
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
-    class Test {
-      public void fn() {
-        try {
-          errorProneMethod();
-        } catch (RuntimeException re) {
-          handleRuntimeException(re);
-        } catch (Exception e) {
-          String variable = "assigning for some reason";
-        } finally {
-          // Relax, it's over
-          new Thingie().call();
+      class Test {
+        public void fn() {
+          try {
+            errorProneMethod();
+          } catch (RuntimeException re) {
+            handleRuntimeException(re);
+          } catch (Exception e) {
+            String variable = "assigning for some reason";
+          } finally {
+            // Relax, it's over
+            new Thingie().call();
+          }
         }
       }
-    }
     '''
 
     scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
@@ -1512,17 +1512,17 @@ describe 'Java grammar', ->
 
   it 'tokenizes nested try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''
-    class Test {
-      public void fn() {
-        try {
+      class Test {
+        public void fn() {
           try {
-            String nested;
-          } catch (Exception e) {
-            handleNestedException();
-          }
-        } catch (RuntimeException re) {}
+            try {
+              String nested;
+            } catch (Exception e) {
+              handleNestedException();
+            }
+          } catch (RuntimeException re) {}
+        }
       }
-    }
     '''
 
     scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java']
@@ -1604,6 +1604,51 @@ describe 'Java grammar', ->
     expect(lines[4][1]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
     expect(lines[4][2]).toEqual value: ' ', scopes: scopes
     expect(lines[4][3]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
+
+  it 'tokenizes list of exceptions in catch block', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        private void method() {
+          try {
+            // do something
+          } catch (Exception1 | Exception2 err) {
+            throw new Exception3();
+          }
+        }
+      }
+      '''
+
+    expect(lines[5][3]).toEqual value: 'catch', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'keyword.control.catch.java']
+    expect(lines[5][5]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[5][6]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[5][8]).toEqual value: '|', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'punctuation.catch.separator']
+    expect(lines[5][10]).toEqual value: 'Exception2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[5][12]).toEqual value: 'err', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'variable.parameter.java']
+    expect(lines[5][13]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.end.bracket.round.java']
+
+  it 'tokenizes list of exceptions in method throws clause', ->
+    lines = grammar.tokenizeLines '''
+      class Test {
+        public void test1() throws Exception1, Exception2 {
+          // throws exceptions
+        }
+
+        public void test2() throws Exception1 {
+          // throws exceptions
+        }
+      }
+    '''
+
+    expect(lines[1][9]).toEqual value: 'throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.modifier.java']
+    expect(lines[1][11]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.type.java']
+    expect(lines[1][12]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'punctuation.throwables.separator']
+    expect(lines[1][14]).toEqual value: 'Exception2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.type.java']
+    expect(lines[1][16]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
+
+    expect(lines[5][9]).toEqual value: 'throws', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.modifier.java']
+    expect(lines[5][11]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.throwables.java', 'storage.type.java']
+    expect(lines[5][13]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
 
   it 'tokenizes comment inside method body', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR updates the code for scopes `meta.catch.java` and `meta.throwables.java` and fixes scoping of exception class names and/or parameters.

For `meta.catch.java` we are currently include `parameters` scope, which is not exactly correct, because parameters are assumed to be `storage + variable`, but in the case of catch block, you could see something like this `Exception1 | Exception2 err`, so we would only highlight the second case. I replaced it with the pattern that scopes `|` as separator and require `storage` and optional `variable` name.

For `meta.throwables.java` we are currently including `object-types` scope, which is also not 100% correct, because they assume `storage` followed by `variable`, but in `throws` you could see something like this `throws Exception1, Exception2`. I changed it to just parse storage type.

```java
class MyClass {
  public void set(String str) throws Exception3, Exception4 {
    try {
      // some code
    } catch (Exception1 | Exception2 e) {
      throw new Exception3();
    }
  }
}
```

Before:
<img width="463" alt="before" src="https://user-images.githubusercontent.com/7788766/40703511-aa77a38e-63e5-11e8-9fc8-543b68c48138.png">

After:
<img width="467" alt="after" src="https://user-images.githubusercontent.com/7788766/40703514-aeb6af1c-63e5-11e8-9825-71e48d445bef.png">

### Alternate Designs
I was considering updating `parameters` and `object-types` scopes, but I found that it would be rather massive change, which might cause the regression in other parts. So I went with this fairly straightforward approach.

### Benefits
Fixes issue of scoping exceptions in `catch` and `throws`.

### Possible Drawbacks
None that I found, it does not affect existing scopes.

### Applicable Issues
Closes #138
