### PR TITLE
Fix highlighting for fully qualified types

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1023,7 +1023,7 @@
         'include': '#generics'
       }
       {
-        'begin': '\\b(?:\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
+        'begin': '\\b(?:[A-Za-z]\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.period.java'
@@ -1041,12 +1041,19 @@
       }
       {
         # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b((?:[A-Za-z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*)\\s*(?=<)'
+        'begin': '\\b((?:[A-Za-z]\\w*\\s*\\.\\s*)*[A-Z]\\w*)\\s*(?=<)'
         'beginCaptures':
           '1':
-            'name': 'storage.type.java'
-          '2':
-            'name': 'punctuation.separator.period.java'
+            'patterns': [
+              {
+                'match': '[A-Za-z]\\w*'
+                'name': 'storage.type.java'
+              }
+              {
+                'match': '\\.'
+                'name': 'punctuation.separator.period.java'
+              }
+            ]
         # Stop after a successful generic match or if we are not at a terminator
         'end': '(?<=>)|(?!;)'
         'patterns': [
@@ -1059,11 +1066,19 @@
         # If the above fails *then* just look for Wow
         # (must be followed by a variable name, we use '\n' to cover multi-line definitions,
         # or varargs for function definitions)
-        'match': '\\b(?:[A-Za-z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))'
-        'name': 'storage.type.java'
+        'match': '\\b((?:[A-Za-z]\\w*\\s*\\.\\s*)*[A-Z]\\w*)\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))'
         'captures':
           '1':
-            'name': 'punctuation.separator.period.java'
+            'patterns': [
+              {
+                'match': '[A-Za-z]\\w*'
+                'name': 'storage.type.java'
+              }
+              {
+                'match': '\\.'
+                'name': 'punctuation.separator.period.java'
+              }
+            ]
       }
     ]
   'object-types-inherited':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1023,10 +1023,19 @@
         'include': '#generics'
       }
       {
-        'begin': '\\b(?:[A-Za-z]\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
+        'begin': '\\b((?:[A-Za-z]\\w*\\s*\\.\\s*)*)([A-Z]\\w*)\\s*(?=\\[)'
         'beginCaptures':
           '1':
-            'name': 'punctuation.separator.period.java'
+            'patterns': [
+              {
+                'match': '[A-Za-z]\\w*'
+                'name': 'storage.type.java'
+              }
+              {
+                'match': '\\.'
+                'name': 'punctuation.separator.period.java'
+              }
+            ]
           '2':
             'name': 'storage.type.object.array.java'
         'end': '(?!\\s*\\[)'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -411,13 +411,13 @@
         'include': '#function-call'
       }
       {
+        'include': '#variables'
+      }
+      {
         'include': '#objects'
       }
       {
         'include': '#properties'
-      }
-      {
-        'include': '#variables'
       }
       {
         'include': '#strings'
@@ -1023,7 +1023,7 @@
         'include': '#generics'
       }
       {
-        'begin': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
+        'begin': '\\b(?:\\w*\\s*(\\.)\\s*)*([A-Z]\\w*)\\s*(?=\\[)'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.period.java'
@@ -1041,7 +1041,7 @@
       }
       {
         # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b((?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*)\\s*(?=<)'
+        'begin': '\\b((?:[A-Za-z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*)\\s*(?=<)'
         'beginCaptures':
           '1':
             'name': 'storage.type.java'
@@ -1059,7 +1059,7 @@
         # If the above fails *then* just look for Wow
         # (must be followed by a variable name, we use '\n' to cover multi-line definitions,
         # or varargs for function definitions)
-        'match': '\\b(?:[A-Z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))'
+        'match': '\\b(?:[A-Za-z]\\w*\\s*(\\.)\\s*)*[A-Z]\\w*\\b((?=\\s*[A-Za-z$_\\n])|(?=\\s*\\.\\.\\.))'
         'name': 'storage.type.java'
         'captures':
           '1':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1452,6 +1452,7 @@ describe 'Java grammar', ->
         java.util.Set<java.util.List<K>> varA = null;
         java.lang.String a = null;
         java.util.List<Integer> b = new java.util.ArrayList<Integer>();
+        java.lang.String[] arr;
       }
     '''
     expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
@@ -1497,6 +1498,14 @@ describe 'Java grammar', ->
     expect(lines[4][21]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.bracket.angle.java']
     expect(lines[4][22]).toEqual value: 'Integer', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.type.generic.java']
     expect(lines[4][23]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.bracket.angle.java']
+
+    expect(lines[5][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[5][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[5][3]).toEqual value: 'lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[5][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[5][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.object.array.java']
+    expect(lines[5][6]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[5][7]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -935,25 +935,6 @@ describe 'Java grammar', ->
     expect(lines[12][3]).toEqual value: '123illegal', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'invalid.illegal.identifier.java']
     expect(lines[12][4]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'punctuation.terminator.java']
 
-  it 'tokenizes fully qualified types', ->
-    lines = grammar.tokenizeLines '''
-      class A {
-        java.util.Set<java.util.List<K>> varA = null;
-        java.lang.String varB = null;
-      }
-    '''
-
-    expect(lines[1][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[1][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
-    expect(lines[1][3]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
-    expect(lines[1][5]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[2][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[2][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
-    expect(lines[2][3]).toEqual value: 'lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[2][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
-    expect(lines[2][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-
   it 'tokenizes generics', ->
     lines = grammar.tokenizeLines '''
       class A<T extends A & B, String, Integer>
@@ -1468,12 +1449,54 @@ describe 'Java grammar', ->
     lines = grammar.tokenizeLines '''
       class Test {
         private Test.Double something;
+        java.util.Set<java.util.List<K>> varA = null;
+        java.lang.String a = null;
+        java.util.List<Integer> b = new java.util.ArrayList<Integer>();
       }
     '''
     expect(lines[1][3]).toEqual value: 'Test', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java']
+    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
     expect(lines[1][5]).toEqual value: 'Double', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
     expect(lines[1][7]).toEqual value: 'something', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+
+    expect(lines[2][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][3]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][5]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][6]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][7]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][8]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][9]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][10]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][11]).toEqual value: 'List', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][12]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][13]).toEqual value: 'K', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[2][14]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[2][15]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+
+    expect(lines[3][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[3][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[3][3]).toEqual value: 'lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[3][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[3][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+
+    expect(lines[4][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[4][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[4][3]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[4][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[4][5]).toEqual value: 'List', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[4][6]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[4][7]).toEqual value: 'Integer', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[4][8]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[4][16]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.type.java']
+    expect(lines[4][17]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.separator.period.java']
+    expect(lines[4][18]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.type.java']
+    expect(lines[4][19]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.separator.period.java']
+    expect(lines[4][20]).toEqual value: 'ArrayList', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.type.java']
+    expect(lines[4][21]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.bracket.angle.java']
+    expect(lines[4][22]).toEqual value: 'Integer', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'storage.type.generic.java']
+    expect(lines[4][23]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'punctuation.bracket.angle.java']
 
   it 'tokenizes try-catch-finally blocks', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -935,6 +935,21 @@ describe 'Java grammar', ->
     expect(lines[12][3]).toEqual value: '123illegal', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'invalid.illegal.identifier.java']
     expect(lines[12][4]).toEqual value: ';', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'punctuation.terminator.java']
 
+  it 'tokenizes fully qualified types', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        java.util.Set<java.util.List<K>> varA = null;
+        java.lang.String varB = null;
+      }
+    '''
+
+    expect(lines[1][1]).toEqual value: 'java.util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][2]).toEqual value: '.', scopes: [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java' ]
+    expect(lines[1][3]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][1]).toEqual value: 'java.lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][2]).toEqual value: '.', scopes: [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java' ]
+    expect(lines[2][3]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+
   it 'tokenizes generics', ->
     lines = grammar.tokenizeLines '''
       class A<T extends A & B, String, Integer>

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -943,12 +943,16 @@ describe 'Java grammar', ->
       }
     '''
 
-    expect(lines[1][1]).toEqual value: 'java.util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[1][2]).toEqual value: '.', scopes: [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java' ]
-    expect(lines[1][3]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[2][1]).toEqual value: 'java.lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
-    expect(lines[2][2]).toEqual value: '.', scopes: [ 'source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java', 'punctuation.separator.period.java' ]
-    expect(lines[2][3]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[1][3]).toEqual value: 'util', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[1][5]).toEqual value: 'Set', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][1]).toEqual value: 'java', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][2]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][3]).toEqual value: 'lang', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][4]).toEqual value: '.', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.separator.period.java']
+    expect(lines[2][5]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
 
   it 'tokenizes generics', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Description of the Change

Fixes issue where types containing periods were being treated as objects and properties, so I included the ```variables``` section before the ```object``` and ```property``` sections to properly recognize fully qualified variables. I also changed the regex for recognizing types to allow namespaces starting with a lowercase letter.

I also added a few specs. 

#### Before:
<img width="426" alt="before" src="https://user-images.githubusercontent.com/28460318/42832504-a83784c4-89ae-11e8-93f8-0ebaf1a4defa.png">

#### After:
<img width="455" alt="after" src="https://user-images.githubusercontent.com/28460318/42832510-ac6e96c2-89ae-11e8-8ebe-7d740b58a2d7.png">



### Alternate Designs

None were considered.

### Benefits

Syntax highlighting is now more accurate, all tests pass

### Possible Drawbacks

None

### Applicable Issues
#135 