### PR TITLE
Simplify some syntax that was more complex than necessary

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1049,9 +1049,9 @@
         ]
       }
       {
-        # Match possible generics first, eg Wow<String> instead of just Wow
-        'begin': '\\b((?:[A-Za-z]\\w*\\s*\\.\\s*)*[A-Z]\\w*)\\s*(?=<)'
-        'beginCaptures':
+        # Match possible generics first, eg Foo.Bar in Foo.Bar<String>
+        'match': '\\b((?:[A-Za-z]\\w*\\s*\\.\\s*)*[A-Z]\\w*)\\s*(?=<)'
+        'captures':
           '1':
             'patterns': [
               {
@@ -1063,13 +1063,6 @@
                 'name': 'punctuation.separator.period.java'
               }
             ]
-        # Stop after a successful generic match or if we are not at a terminator
-        'end': '(?<=>)|(?!;)'
-        'patterns': [
-          {
-            'include': '#generics'
-          }
-        ]
       }
       {
         # If the above fails *then* just look for Wow


### PR DESCRIPTION
### Description of the Change

The end tag for the block was ```(?<=>)|(?!;)```, which could be simplified to ```(?!;)``` since that always matches the next character after the begin block. This makes the size of the block 0, so nothing is actually happening inside the block, just in the beginCaptures, so I just converted the beginCaptures to their own matching group.

### Alternate Designs

I tried to figure out if this was originally intended to do something else, but I couldn't get that syntax to do anything useful even in simple cases. 

### Benefits

The code is easier to understand.

### Possible Drawbacks

This might have had some other purpose I'm not seeing, but if so it wasn't working. This fix doesn't change the behavior at all. 

### Applicable Issues

None