### PR TITLE
Variables rule causes loop

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1309,7 +1309,7 @@
     'begin': '''(?x)
       (?=
         (
-          (void|boolean|byte|char|short|int|float|long|double)
+          \\b(void|boolean|byte|char|short|int|float|long|double)\\b
           |
           (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )


### PR DESCRIPTION
Fixes #151

The "variables" rule looks for the occurrence of `int` without making that sure that this is a separate word, however, the subpatterns of the  "variables" rule depends on that.
As the variable rule only consists of lookahead, this causes a loop with the rule to be entered and exited again.

VSCode prints a warning when that happens, Atom silently ignores.
However, both VSCode and Atom do not highlight the rest of the line anymore.
