### PR TITLE
Fix inconsistent enum highlighting

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -551,13 +551,33 @@
             'end': '(?=;|})'
             'patterns': [
               {
+                'include': '#comments-javadoc'
+              }
+              {
                 'include': '#comments'
               }
+              # Represents enum's constant field with constructor, e.g. `Test(123)`
               {
-                'include': '#enum-method-field'
+                'begin': '(\\w+)\\s*(\\()'
+                'beginCaptures':
+                  '1':
+                    'name': 'constant.other.enum.java'
+                  '2':
+                    'name': 'punctuation.bracket.round.java'
+                'end': '\\)'
+                'endCaptures':
+                  '0':
+                    'name': 'punctuation.bracket.round.java'
+                'patterns': [
+                  {
+                    'include': '#code'
+                  }
+                ]
               }
+              # Represents enum's constant field, e.g. `Test`
               {
-                'include': '#enum-constant-field'
+                'match': '\\b\\w+\\b'
+                'name': 'constant.other.enum.java'
               }
             ]
           }
@@ -578,34 +598,6 @@
       }
       {
         'include': '#storage-modifiers'
-      }
-    ]
-  # Represents enum's constant field with constructor
-  'enum-method-field':
-    'begin': '(\\w+)\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'constant.other.enum.java'
-      '2':
-        'name': 'punctuation.bracket.round.java'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.bracket.round.java'
-    'patterns': [
-      {
-        'include': '#numbers'
-      }
-      {
-        'include': '#strings'
-      }
-    ]
-  # Represents enum's constant field without constructor
-  'enum-constant-field':
-    'patterns': [
-      {
-        'match': '\\b\\w+\\b'
-        'name': 'constant.other.enum.java'
       }
     ]
   'function-call':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -551,8 +551,13 @@
             'end': '(?=;|})'
             'patterns': [
               {
-                'match': '\\w+'
-                'name': 'constant.other.enum.java'
+                'include': '#comments'
+              }
+              {
+                'include': '#enum-method-field'
+              }
+              {
+                'include': '#enum-constant-field'
               }
             ]
           }
@@ -566,11 +571,41 @@
         'name': 'storage.modifier.java'
       }
       {
-        'match': '(?<=enum)\\s*\\w+'
-        'name': 'entity.name.type.enum.java'
+        'match': '(?<=enum)\\s*(\\w+)'
+        'captures':
+          '1':
+            'name': 'entity.name.type.enum.java'
       }
       {
         'include': '#storage-modifiers'
+      }
+    ]
+  # Represents enum's constant field with constructor
+  'enum-method-field':
+    'begin': '(\\w+)\\s*(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'constant.other.enum.java'
+      '2':
+        'name': 'punctuation.bracket.round.java'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.bracket.round.java'
+    'patterns': [
+      {
+        'include': '#numbers'
+      }
+      {
+        'include': '#strings'
+      }
+    ]
+  # Represents enum's constant field without constructor
+  'enum-constant-field':
+    'patterns': [
+      {
+        'match': '\\b\\w+\\b'
+        'name': 'constant.other.enum.java'
       }
     ]
   'function-call':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -532,7 +532,18 @@
       }
     ]
   'enums':
-    'begin': '^\\s*(?=\\w?[\\w\\s]*enum\\s+\\w+)'
+    'begin': '^\\s*([\\w\\s]*)(enum)\\s+(\\w+)'
+    'beginCaptures':
+      '1':
+        'patterns': [
+          {
+            'include': '#storage-modifiers'
+          }
+        ]
+      '2':
+        'name': 'storage.modifier.java'
+      '3':
+        'name': 'entity.name.type.enum.java'
     'end': '}'
     'endCaptures':
       '0':
@@ -585,19 +596,6 @@
             'include': '#class-body'
           }
         ]
-      }
-      {
-        'match': '\\b(enum)\\b'
-        'name': 'storage.modifier.java'
-      }
-      {
-        'match': '(?<=enum)\\s*(\\w+)'
-        'captures':
-          '1':
-            'name': 'entity.name.type.enum.java'
-      }
-      {
-        'include': '#storage-modifiers'
       }
     ]
   'function-call':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -323,10 +323,10 @@
         'include': '#comments'
       }
       {
-        'include': '#class'
+        'include': '#enums'
       }
       {
-        'include': '#enums'
+        'include': '#class'
       }
       {
         'include': '#generics'
@@ -532,12 +532,7 @@
       }
     ]
   'enums':
-    'begin': '^\\s*(enum)\\s+(\\w+)'
-    'beginCaptures':
-      '1':
-        'name': 'storage.modifier.java'
-      '2':
-        'name': 'entity.name.type.enum.java'
+    'begin': '^\\s*(?=\\w?[\\w\\s]*enum\\s+\\w+)'
     'end': '}'
     'endCaptures':
       '0':
@@ -552,8 +547,14 @@
         'end': '(?=})'
         'patterns': [
           {
-            'match': '\\w+'
-            'name': 'constant.other.enum.java'
+            'begin': '(?<={)'
+            'end': '(?=;|})'
+            'patterns': [
+              {
+                'match': '\\w+'
+                'name': 'constant.other.enum.java'
+              }
+            ]
           }
           {
             'include': '#class-body'
@@ -561,7 +562,15 @@
         ]
       }
       {
-        'include': '#comments'
+        'match': '\\b(enum)\\b'
+        'name': 'storage.modifier.java'
+      }
+      {
+        'match': '(?<=enum)\\s*\\w+'
+        'name': 'entity.name.type.enum.java'
+      }
+      {
+        'include': '#storage-modifiers'
       }
     ]
   'function-call':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -225,12 +225,19 @@ describe 'Java grammar', ->
         A,
 
         // Comment about B
-        B
+        B,
+
+        /** Javadoc comment about C */
+        C
       }
     '''
 
     comment = ['source.java', 'meta.enum.java', 'comment.block.java']
+    commentLine = ['source.java', 'meta.enum.java', 'comment.line.double-slash.java']
+    commentJavadoc = ['source.java', 'meta.enum.java', 'comment.block.javadoc.java']
     commentDefinition = comment.concat('punctuation.definition.comment.java')
+    commentLineDefinition = commentLine.concat('punctuation.definition.comment.java')
+    commentJavadocDefinition = commentJavadoc.concat('punctuation.definition.comment.java')
 
     expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
     expect(lines[0][2]).toEqual value: 'Letters', scopes: ['source.java', 'meta.enum.java', 'entity.name.type.enum.java']
@@ -239,7 +246,108 @@ describe 'Java grammar', ->
     expect(lines[1][2]).toEqual value: ' Comment about A ', scopes: comment
     expect(lines[1][3]).toEqual value: '*/', scopes: commentDefinition
     expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
-    expect(lines[6][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
+    expect(lines[4][1]).toEqual value: '//', scopes: commentLineDefinition
+    expect(lines[4][2]).toEqual value: ' Comment about B', scopes: commentLine
+    expect(lines[5][1]).toEqual value: 'B', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[7][0]).toEqual value: '  /**', scopes: commentJavadocDefinition
+    expect(lines[7][1]).toEqual value: ' Javadoc comment about C ', scopes: commentJavadoc
+    expect(lines[8][1]).toEqual value: 'C', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[9][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
+
+  it 'tokenizes enums with class body', ->
+    lines = grammar.tokenizeLines '''
+      enum Colours {
+        RED ("red"),
+        GREEN (1000L),
+        BLUE (123);
+
+        private String v;
+
+        Colours(String v) {
+          this.v = v;
+        }
+
+        Colours(long v) {
+          this.v = "" + v;
+        }
+
+        Colours(int v) {
+          this.v = "" + v;
+        }
+
+        public String func() {
+          return "RGB";
+        }
+      }
+    '''
+
+    expect(lines[0][0]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[0][2]).toEqual value: 'Colours', scopes: ['source.java', 'meta.enum.java', 'entity.name.type.enum.java']
+    expect(lines[0][4]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.begin.bracket.curly.java']
+
+    expect(lines[1][1]).toEqual value: 'RED', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[1][3]).toEqual value: '(', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[1][5]).toEqual value: 'red', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java']
+    expect(lines[1][7]).toEqual value: ')', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+
+    expect(lines[2][1]).toEqual value: 'GREEN', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[2][3]).toEqual value: '(', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[2][4]).toEqual value: '1000L', scopes: ['source.java', 'meta.enum.java', 'constant.numeric.decimal.java']
+    expect(lines[2][5]).toEqual value: ')', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+
+    expect(lines[3][1]).toEqual value: 'BLUE', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[3][3]).toEqual value: '(', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[3][4]).toEqual value: '123', scopes: ['source.java', 'meta.enum.java', 'constant.numeric.decimal.java']
+    expect(lines[3][5]).toEqual value: ')', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+
+    expect(lines[19][1]).toEqual value: 'public', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'storage.modifier.java']
+    expect(lines[19][3]).toEqual value: 'String', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.java']
+    expect(lines[19][5]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[22][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
+
+  it 'tokenizes enums with modifiers', ->
+    lines = grammar.tokenizeLines '''
+      public enum Test {
+      }
+
+      private enum Test {
+      }
+
+      protected enum Test {
+      }
+
+      unknown enum Test {
+      }
+    '''
+
+    expect(lines[0][0]).toEqual value: 'public', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[3][0]).toEqual value: 'private', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[3][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[6][0]).toEqual value: 'protected', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[6][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[9][0]).toEqual value: 'unknown ', scopes: ['source.java', 'meta.enum.java']
+    expect(lines[9][1]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
+
+  it 'tokenizes enums within a class', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        public enum Colours {
+          RED,
+          GREEN,
+          BLUE
+        }
+      }
+    '''
+
+    expect(lines[1][1]).toEqual value: 'public', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[1][3]).toEqual value: 'enum', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'storage.modifier.java']
+    expect(lines[1][5]).toEqual value: 'Colours', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'entity.name.type.enum.java']
+    expect(lines[1][7]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'punctuation.section.enum.begin.bracket.curly.java']
+    expect(lines[2][1]).toEqual value: 'RED', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[3][1]).toEqual value: 'GREEN', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[4][1]).toEqual value: 'BLUE', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[5][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
 
   it 'does not catastrophically backtrack when tokenizing large enums (regression)', ->
     # https://github.com/atom/language-java/issues/103

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -254,7 +254,7 @@ describe 'Java grammar', ->
       }
     """
 
-    expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
+    expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
 
   it 'tokenizes methods', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -249,8 +249,8 @@ describe 'Java grammar', ->
     expect(lines[4][1]).toEqual value: '//', scopes: commentLineDefinition
     expect(lines[4][2]).toEqual value: ' Comment about B', scopes: commentLine
     expect(lines[5][1]).toEqual value: 'B', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
-    expect(lines[7][0]).toEqual value: '  /**', scopes: commentJavadocDefinition
-    expect(lines[7][1]).toEqual value: ' Javadoc comment about C ', scopes: commentJavadoc
+    expect(lines[7][1]).toEqual value: '/**', scopes: commentJavadocDefinition
+    expect(lines[7][2]).toEqual value: ' Javadoc comment about C ', scopes: commentJavadoc
     expect(lines[8][1]).toEqual value: 'C', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
     expect(lines[9][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes enum scope and highlighting to make sure that we can handle different variations of enums, e.g. 
```java
enum Test {
  A, B, C
}
```

```java
protected enum Test {
  A(123),
  B(234);

  void func() {
    ...
  }
}
```

```java
class A {
  private enum Test {
    A,
    B,
    C
  }
}
```

The proposed design extends the existing `enum` scope and adds handling of storage modifiers (`private`, `protected`, etc.) and fixes issues when enum constants were not highlighted correctly in nested enums. I also extended the existing tests and added new ones to cover added functionality.

### Alternate Designs

None apart from the one mentioned in description above.

### Benefits

Fixes scope and highlighting for various enums, that were not supported previously.

### Possible Drawbacks

Not many, since it only affects enums.

### Applicable Issues

Closes #154 
