### PR TITLE
Fix comments-javadoc scope

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -474,9 +474,9 @@
     ]
   'comments-javadoc':
     'patterns': [
-      'begin': '^\\s*/\\*\\*(?!/)'
+      'begin': '^\\s*(/\\*\\*)(?!/)'
       'beginCaptures':
-        '0':
+        '1':
           'name': 'punctuation.definition.comment.java'
       'end': '\\*/'
       'endCaptures':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1831,13 +1831,13 @@ describe 'Java grammar', ->
       }
       '''
 
-    expect(lines[1][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
-    expect(lines[1][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java']
-    expect(lines[1][2]).toEqual value: '*/', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[1][1]).toEqual value: '/**', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[1][2]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java']
+    expect(lines[1][3]).toEqual value: '*/', scopes: ['source.java', 'meta.enum.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
-    expect(lines[5][0]).toEqual value: '  /**', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
-    expect(lines[5][1]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
-    expect(lines[5][2]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[5][1]).toEqual value: '/**', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
+    expect(lines[5][2]).toEqual value: ' javadoc comment ', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
+    expect(lines[5][3]).toEqual value: '*/', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'punctuation.definition.comment.java']
 
   it 'tokenizes empty/single character comment', ->
     # this test checks the correct tokenizing of empty/single character comments


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes scope for the comment start of `comments-javadoc`. Previously we would include any whitespace into comment start, e.g. `|        /**`. This patch fixes it and only marks `/**` as a comment start.

### Alternate Designs

None were considered, since it is fairly simple change.

### Benefits

Fixes the scoping of a javadoc comment start.

### Possible Drawbacks

Should not be any.

### Applicable Issues

None
