### PR TITLE
Wrong syntax highlighting in field value

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1360,6 +1360,7 @@
       )
     '''
     'end': '(?=\\=|;)'
+    'applyEndPatternLast': 1
     'name': 'meta.definition.variable.java'
     'patterns': [
       {


### PR DESCRIPTION
Fixes #158

See discussion in #158.
The problem is that the end pattern of the `variables` rule consumes the `=`.

I suggest to fix this by adding 'applyEndPatternLast': 1 to the variable rule.
That way the end pattern is evaluated after all the #code patterns.

This was already present in https://github.com/atom/language-java/commit/6991cbc38c6953aafc2ebfc008e1119fb266edb2#diff-854de79c7abc9c505592fcddfc4654f9