### PR TITLE
Fix regression of field values being incorrectly highlighted

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -438,9 +438,6 @@
         'name': 'comment.block.empty.java'
       }
       {
-        'include': 'text.html.javadoc'
-      }
-      {
         'include': '#comments-inline'
       }
     ]
@@ -771,7 +768,7 @@
       }
     ]
   'methods':
-    'begin': '(?!new)(?=[\\w<].*\\s+)(?=([^=/]|/(?!/))+\\()'
+    'begin': '(?!new)(?=[\\w<].*\\s+)(?=[\\w\\s\\[\\]<>,\\.\\?/\\*]+\\()'
     'end': '(})|(?=;)'
     'endCaptures':
       '1':
@@ -780,6 +777,9 @@
     'patterns': [
       {
         'include': '#storage-modifiers'
+      }
+      {
+        'include': '#comments'
       }
       {
         'begin': '(\\w+)\\s*(\\()'
@@ -801,7 +801,7 @@
             'include': '#parens'
           }
           {
-            'include': '#comments-inline'
+            'include': '#comments'
           }
         ]
       }

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -352,9 +352,9 @@
     ]
   'class-fields-and-methods':
     # Pattern to match both class fields and method declarations inside class body.
-    # For class fields, we only need to match part after '=', because the first part will be matched
-    # using 'variables' pattern. Only then we apply pattern to match methods, because it is not strict
-    # and could potentially match functions in the code (issue #158).
+    # For class fields, we only need to match part after '=', because the first part will be
+    # matched using 'variables' pattern. Only then we apply pattern to match methods, because
+    # it is not strict and could potentially match functions in the code (issue #158).
     'patterns': [
       {
         'begin': '(?=\\=)'

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -350,6 +350,25 @@
         'include': '#code'
       }
     ]
+  'class-fields-and-methods':
+    # Pattern to match both class fields and method declarations inside class body.
+    # For class fields, we only need to match part after '=', because the first part will be matched
+    # using 'variables' pattern. Only then we apply pattern to match methods, because it is not strict
+    # and could potentially match functions in the code (issue #158).
+    'patterns': [
+      {
+        'begin': '(?=\\=)'
+        'end': '(?=;)'
+        'patterns': [
+          {
+            'include': '#code'
+          }
+        ]
+      }
+      {
+        'include': '#methods'
+      }
+    ]
   'code':
     'patterns': [
       {
@@ -765,25 +784,6 @@
     'patterns': [
       {
         'include': '#code'
-      }
-    ]
-  'class-fields-and-methods':
-    # Pattern to match both class fields and method declarations inside class body.
-    # For class fields, we only need to match part after '=', because the first part will be matched
-    # using 'variables' pattern. Only then we apply pattern to match methods, because it is not strict
-    # and could potentially match functions in the code (issue #158).
-    'patterns': [
-      {
-        'begin': '(?=\\=)'
-        'end': '(?=;)'
-        'patterns': [
-          {
-            'include': '#code'
-          }
-        ]
-      }
-      {
-        'include': '#methods'
       }
     ]
   'methods':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -335,7 +335,7 @@
         'include': '#static-initializer'
       }
       {
-        'include': '#methods'
+        'include': '#class-fields-and-methods'
       }
       {
         'include': '#annotations'
@@ -767,8 +767,27 @@
         'include': '#code'
       }
     ]
+  'class-fields-and-methods':
+    # Pattern to match both class fields and method declarations inside class body.
+    # For class fields, we only need to match part after '=', because the first part will be matched
+    # using 'variables' pattern. Only then we apply pattern to match methods, because it is not strict
+    # and could potentially match functions in the code (issue #158).
+    'patterns': [
+      {
+        'begin': '(?=\\=)'
+        'end': '(?=;)'
+        'patterns': [
+          {
+            'include': '#code'
+          }
+        ]
+      }
+      {
+        'include': '#methods'
+      }
+    ]
   'methods':
-    'begin': '(?!new)(?=[\\w<].*\\s+)(?=[\\w\\s\\[\\]<>,\\.\\?/\\*]+\\()'
+    'begin': '(?!new)(?=[\\w<].*\\s+)(?=([^=/]|/(?!/))+\\()'
     'end': '(})|(?=;)'
     'endCaptures':
       '1':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -816,6 +816,9 @@
           {
             'include': '#parens'
           }
+          {
+            'include': '#comments'
+          }
         ]
       }
       {

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -779,9 +779,6 @@
         'include': '#storage-modifiers'
       }
       {
-        'include': '#comments'
-      }
-      {
         'begin': '(\\w+)\\s*(\\()'
         'beginCaptures':
           '1':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -364,24 +364,110 @@ describe 'Java grammar', ->
 
     expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
 
-  it 'tokenizes methods', ->
+  fit 'tokenizes methods', ->
     lines = grammar.tokenizeLines '''
-      class A
+      abstract class A
       {
         A(int a, int b)
         {
+          super();
+          this.prop = a + b;
         }
+
+        public /* test */ List<Integer> /* test */ getList() /* test */ throws Exception
+        {
+          return null;
+        }
+
+        public void nothing();
+
+        public java.lang.String[][] getString()
+        {
+          return null;
+        }
+
+        public Map<Integer, Integer> getMap()
+        {
+          return null;
+        }
+
+        public <T extends Box> T call(String name, Class<T> type)
+        {
+          return null;
+        }
+
+        private int prop = 0;
       }
     '''
 
-    expect(lines[2][1]).toEqual value: 'A', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
-    expect(lines[2][2]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java']
-    expect(lines[2][3]).toEqual value: 'int', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'storage.type.primitive.java']
-    expect(lines[2][5]).toEqual value: 'a', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'variable.parameter.java']
-    expect(lines[2][6]).toEqual value: ',', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.separator.delimiter.java']
-    expect(lines[2][11]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java']
-    expect(lines[3][1]).toEqual value: '{', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.begin.bracket.curly.java']
-    expect(lines[4][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'punctuation.section.method.end.bracket.curly.java']
+    scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java']
+
+    expect(lines[2][1]).toEqual value: 'A', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[2][2]).toEqual value: '(', scopes: scopeStack.concat  ['meta.method.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[2][3]).toEqual value: 'int', scopes: scopeStack.concat ['meta.method.identifier.java', 'storage.type.primitive.java']
+    expect(lines[2][5]).toEqual value: 'a', scopes: scopeStack.concat ['meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[2][6]).toEqual value: ',', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.separator.delimiter.java']
+    expect(lines[2][11]).toEqual value: ')', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java']
+    expect(lines[3][1]).toEqual value: '{', scopes: scopeStack.concat ['punctuation.section.method.begin.bracket.curly.java']
+    expect(lines[4][1]).toEqual value: 'super', scopes: scopeStack.concat ['meta.method.body.java', 'variable.language.java']
+    expect(lines[5][1]).toEqual value: 'this', scopes: scopeStack.concat ['meta.method.body.java', 'variable.language.this.java']
+    expect(lines[5][3]).toEqual value: 'prop', scopes: scopeStack.concat ['meta.method.body.java', 'variable.other.property.java']
+    expect(lines[6][1]).toEqual value: '}', scopes: scopeStack.concat ['punctuation.section.method.end.bracket.curly.java']
+
+    expect(lines[8][1]).toEqual value: 'public', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[8][4]).toEqual value: ' test ', scopes: scopeStack.concat ['comment.block.java']
+    expect(lines[8][7]).toEqual value: 'List', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.java']
+    expect(lines[8][8]).toEqual value: '<', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][9]).toEqual value: 'Integer', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.generic.java']
+    expect(lines[8][10]).toEqual value: '>', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.angle.java']
+    expect(lines[8][13]).toEqual value: ' test ', scopes: scopeStack.concat ['meta.method.return-type.java', 'comment.block.java']
+    expect(lines[8][16]).toEqual value: 'getList', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[8][21]).toEqual value: ' test ', scopes: scopeStack.concat ['comment.block.java']
+    expect(lines[8][24]).toEqual value: 'throws', scopes: scopeStack.concat ['meta.throwables.java', 'storage.modifier.java']
+    expect(lines[8][26]).toEqual value: 'Exception', scopes: scopeStack.concat ['meta.throwables.java', 'storage.type.java']
+
+    expect(lines[13][1]).toEqual value: 'public', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[13][3]).toEqual value: 'void', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[13][5]).toEqual value: 'nothing', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[13][6]).toEqual value: '(', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[13][7]).toEqual value: ')', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java']
+
+    expect(lines[15][1]).toEqual value: 'public', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[15][3]).toEqual value: 'java', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.java']
+    expect(lines[15][5]).toEqual value: 'lang', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.java']
+    expect(lines[15][7]).toEqual value: 'String', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.object.array.java']
+    expect(lines[15][8]).toEqual value: '[', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.square.java']
+    expect(lines[15][9]).toEqual value: ']', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.square.java']
+    expect(lines[15][10]).toEqual value: '[', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.square.java']
+    expect(lines[15][11]).toEqual value: ']', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.square.java']
+    expect(lines[15][13]).toEqual value: 'getString', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+
+    expect(lines[20][1]).toEqual value: 'public', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[20][3]).toEqual value: 'Map', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.java']
+    expect(lines[20][4]).toEqual value: '<', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.angle.java']
+    expect(lines[20][5]).toEqual value: 'Integer', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.generic.java']
+    expect(lines[20][8]).toEqual value: 'Integer', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.generic.java']
+    expect(lines[20][9]).toEqual value: '>', scopes: scopeStack.concat ['meta.method.return-type.java', 'punctuation.bracket.angle.java']
+    expect(lines[20][11]).toEqual value: 'getMap', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+
+    expect(lines[25][1]).toEqual value: 'public', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[25][3]).toEqual value: '<', scopes: scopeStack.concat ['punctuation.bracket.angle.java']
+    expect(lines[25][4]).toEqual value: 'T', scopes: scopeStack.concat ['storage.type.generic.java']
+    expect(lines[25][6]).toEqual value: 'extends', scopes: scopeStack.concat ['storage.modifier.extends.java']
+    expect(lines[25][8]).toEqual value: 'Box', scopes: scopeStack.concat ['storage.type.generic.java']
+    expect(lines[25][9]).toEqual value: '>', scopes: scopeStack.concat ['punctuation.bracket.angle.java']
+    expect(lines[25][11]).toEqual value: 'T', scopes: scopeStack.concat ['meta.method.return-type.java', 'storage.type.java']
+    expect(lines[25][13]).toEqual value: 'call', scopes: scopeStack.concat ['meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[25][14]).toEqual value: '(', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[25][15]).toEqual value: 'String', scopes: scopeStack.concat ['meta.method.identifier.java', 'storage.type.java']
+    expect(lines[25][17]).toEqual value: 'name', scopes: scopeStack.concat ['meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[25][20]).toEqual value: 'Class', scopes: scopeStack.concat ['meta.method.identifier.java', 'storage.type.java']
+    expect(lines[25][21]).toEqual value: '<', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.bracket.angle.java']
+    expect(lines[25][22]).toEqual value: 'T', scopes: scopeStack.concat ['meta.method.identifier.java', 'storage.type.generic.java']
+    expect(lines[25][23]).toEqual value: '>', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.bracket.angle.java']
+    expect(lines[25][25]).toEqual value: 'type', scopes: scopeStack.concat ['meta.method.identifier.java', 'variable.parameter.java']
+    expect(lines[25][26]).toEqual value: ')', scopes: scopeStack.concat ['meta.method.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java']
+
 
   it 'tokenizes variable-length argument list (varargs)', ->
     lines = grammar.tokenizeLines '''
@@ -1567,6 +1653,60 @@ describe 'Java grammar', ->
     expect(lines[15][4]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[15][5]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[15][6]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+
+  it 'tokenizes class fields with complex definitions', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        private String a = func();
+        private String b = a + "a()" + a() + "" + "a();" + "" + a() + abc + b() + "b();";
+        private String c = "a / a();";
+        private int d[] = a + "a();" + func();
+
+        int abcd() {
+          return 1;
+        }
+      }
+    '''
+
+    scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java']
+
+    expect(lines[1][1]).toEqual value: 'private', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[1][3]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
+    expect(lines[1][5]).toEqual value: 'a', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[1][7]).toEqual value: '=', scopes: scopeStack.concat ['keyword.operator.assignment.java']
+    expect(lines[1][9]).toEqual value: 'func', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
+
+    expect(lines[2][1]).toEqual value: 'private', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[2][3]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
+    expect(lines[2][5]).toEqual value: 'b', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[2][7]).toEqual value: '=', scopes: scopeStack.concat ['keyword.operator.assignment.java']
+    expect(lines[2][8]).toEqual value: ' a ', scopes: scopeStack
+    expect(lines[2][12]).toEqual value: 'a()', scopes: scopeStack.concat ['string.quoted.double.java']
+    expect(lines[2][17]).toEqual value: 'a', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
+    expect(lines[2][29]).toEqual value: 'a();', scopes: scopeStack.concat ['string.quoted.double.java']
+    expect(lines[2][39]).toEqual value: 'a', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
+    expect(lines[2][44]).toEqual value: ' abc ', scopes: scopeStack
+    expect(lines[2][47]).toEqual value: 'b', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
+    expect(lines[2][54]).toEqual value: 'b();', scopes: scopeStack.concat ['string.quoted.double.java']
+
+    expect(lines[3][1]).toEqual value: 'private', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[3][3]).toEqual value: 'String', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.java']
+    expect(lines[3][5]).toEqual value: 'c', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[3][7]).toEqual value: '=', scopes: scopeStack.concat ['keyword.operator.assignment.java']
+    expect(lines[3][10]).toEqual value: 'a / a();', scopes: scopeStack.concat ['string.quoted.double.java']
+
+    expect(lines[4][1]).toEqual value: 'private', scopes: scopeStack.concat ['storage.modifier.java']
+    expect(lines[4][3]).toEqual value: 'int', scopes: scopeStack.concat ['meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[4][5]).toEqual value: 'd', scopes: scopeStack.concat ['meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[4][6]).toEqual value: '[', scopes: scopeStack.concat ['meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[4][7]).toEqual value: ']', scopes: scopeStack.concat ['meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[4][9]).toEqual value: '=', scopes: scopeStack.concat ['keyword.operator.assignment.java']
+    expect(lines[4][10]).toEqual value: ' a ', scopes: scopeStack
+    expect(lines[4][14]).toEqual value: 'a();', scopes: scopeStack.concat ['string.quoted.double.java']
+    expect(lines[4][19]).toEqual value: 'func', scopes: scopeStack.concat ['meta.function-call.java', 'entity.name.function.java']
+
+    expect(lines[6][1]).toEqual value: 'int', scopes: scopeStack.concat ['meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[6][3]).toEqual value: 'abcd', scopes: scopeStack.concat ['meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
 
   it 'tokenizes qualified storage types', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -364,7 +364,7 @@ describe 'Java grammar', ->
 
     expect(lines[0][2]).toEqual value: 'enum', scopes: ['source.java', 'meta.enum.java', 'storage.modifier.java']
 
-  fit 'tokenizes methods', ->
+  it 'tokenizes methods', ->
     lines = grammar.tokenizeLines '''
       abstract class A
       {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes the regression reported in #158. This happened because our variable definition now ends with `=`, and the rest is supposed to be matched by the code, which does happen correctly, but it breaks in certain scenarios when using class fields, e.g.
```java
class A {
  private String b = a + "a()" + a() + "" + "a();" + "" + a() + abc + b() + "b();";
  private String c = "a / a();";
  private int d[] = a + "a();" + func();

  int abcd() {
    return 1;
  }
}
```

### Before
<img width="691" alt="before" src="https://user-images.githubusercontent.com/7788766/45589511-114e3000-b927-11e8-98c9-94b52dc37f8f.png">

### After
<img width="691" alt="after" src="https://user-images.githubusercontent.com/7788766/45589512-13b08a00-b927-11e8-8083-3eb0fd051069.png">


All of the `b`, `c`, and `d` would break a subsequent highlighting and scope of method `abcd`.

The fix is fairly straightforward and might seem as a hack. We define `#class-fields-and-methods` scope instead of `#methods` and first match anything like this `... = [...];`, where `[...]` is covered by `#code`, and only then we match methods. This seems to work quite well.

I also fixed comments in methods, while I was there. Added tests for both methods and class fields.

### Alternate Designs

I considered reverting #146 at some point, but then we would still have to solve `;` issue in try with resources, and, to be fair, the change in that PR was more or less reasonable.

I also tried updating pattern for `#methods` scope trying to restrict it, so that it does not show up in the expression part. It turned out to be quite difficult, mostly because of the return type and parameter types being potentially anything, which complicated the task. For example, I tried writing something like this: 
```cson
'methods':
    'begin': '(?!new)(?=[\\w<].*\\s+)(?=[\\w\\s\\[\\]<>,\\.\\?/\\*]+\\()'
```
But it did not work in certain cases.

### Benefits

Fixes the regression introduced by #146.

### Possible Drawbacks

Could potentially miss coverage of some other case.

### Applicable Issues

Closes #158
