### PR TITLE
Variable highlighting in for-each loop

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1356,14 +1356,14 @@
         \\s+
         [A-Za-z_$][\\w$]* # At least one identifier after space
         ([\\w\\[\\],$][\\w\\[\\],\\s]*)? # possibly primitive array or additional identifiers
-        \\s*(=|;)
+        \\s*(=|:|;)
       )
     '''
-    'end': '(?=\\=|;)'
+    'end': '(?=\\=|:|;)'
     'name': 'meta.definition.variable.java'
     'patterns': [
       {
-        'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|=|,))'
+        'match': '([A-Za-z$_][\\w$]*)(?=\\s*(\\[\\])*\\s*(;|:|=|,))'
         'captures':
           '1':
             'name': 'variable.other.definition.java'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -964,6 +964,30 @@ describe 'Java grammar', ->
     expect(lines[7][5]).toEqual value: '>', scopes: ['source.java', 'keyword.operator.comparison.java']
     expect(lines[7][6]).toEqual value: ' g', scopes: ['source.java']
 
+  it 'tokenizes variables in for-each loop', ->
+    lines = grammar.tokenizeLines '''
+      void func()
+      {
+        for (int i : elements) {
+          // do something
+        }
+
+        for (HashMap<String, String> map : elementsFunc()) {
+          // do something
+        }
+      }
+    '''
+
+    expect(lines[2][3]).toEqual value: '(', scopes: ['source.java', 'punctuation.bracket.round.java']
+    expect(lines[2][4]).toEqual value: 'int', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.primitive.java']
+    expect(lines[2][6]).toEqual value: 'i', scopes: ['source.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[2][10]).toEqual value: ')', scopes: ['source.java', 'punctuation.bracket.round.java']
+
+    expect(lines[6][3]).toEqual value: '(', scopes: ['source.java', 'punctuation.bracket.round.java']
+    expect(lines[6][4]).toEqual value: 'HashMap', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[6][12]).toEqual value: 'map', scopes: ['source.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+    expect(lines[6][19]).toEqual value: ')', scopes: ['source.java', 'punctuation.bracket.round.java']
+
   it 'tokenizes function and method calls', ->
     lines = grammar.tokenizeLines '''
       class A


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I found when working on other issue that variables in for-each loops are not scoped correctly, for example:
```java
class Test {
  void func() {
    // correctly highlighted in for loop
    for (int i = 0; i < 10; i++) {
      // do something
    }

    // incorrectly highlighted and scoped in for-each loop
    for (int i : elements) {
      // do something
    }

    // incorrectly highlighted and scoped in for-each loop
    for (HashMap<String, String> map : elementsFunc()) {
      // do something
    }
  }
}
```

Before patch:
<img width="438" alt="before" src="https://user-images.githubusercontent.com/7788766/45925619-68509800-bf19-11e8-9975-44d9a06aa87d.png">

After patch:
<img width="436" alt="after" src="https://user-images.githubusercontent.com/7788766/45925623-6d154c00-bf19-11e8-895e-5cce9abcf38c.png">

I simply extended the list of characters that terminate variable patterns and added `:` as such. Added test to cover this scenario.

### Alternate Designs

None were considered.

### Benefits

Fixes variable highlighting in for-each loops.

### Possible Drawbacks

Should not be any.

### Applicable Issues

None
