### PR TITLE
Fix syntax highlighting for class pattern

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -243,7 +243,7 @@
       }
     ]
   'class':
-    'begin': '(?=\\w?[\\w\\s]*(?:class|(?<!@)interface|enum)\\s+\\w+)'
+    'begin': '(?=\\w?[\\w\\s]*\\b(?:class|(?<!@)interface|enum)\\s+\\w+)'
     'end': '}'
     'endCaptures':
       '0':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -213,10 +213,29 @@ describe 'Java grammar', ->
       class Thing {
         int x;
       }
+
+      class classA {
+        int a;
+      }
+
+      class Aclass {
+        int b;
+      }
+
+      public static void main(String[] args) {
+        Testclass test1 = null;
+        TestClass test2 = null;
+      }
     '''
 
     expect(lines[0][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
     expect(lines[0][2]).toEqual value: 'Thing', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
+    expect(lines[4][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
+    expect(lines[4][2]).toEqual value: 'classA', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
+    expect(lines[8][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
+    expect(lines[8][2]).toEqual value: 'Aclass', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
+    expect(lines[13][1]).toEqual value: 'Testclass', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[14][1]).toEqual value: 'TestClass', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
 
   it 'tokenizes enums', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes issue with syntax highlighting of a storage type when it ends with `class`. I simply added word boundary to the class pattern, this seems to fix the problem.

Before:
<img width="308" alt="before" src="https://user-images.githubusercontent.com/7788766/47619029-36af8b80-dada-11e8-97eb-8cf16c28f68e.png">

After:
<img width="310" alt="after" src="https://user-images.githubusercontent.com/7788766/47619030-3c0cd600-dada-11e8-8565-c4ff20f53542.png">

### Alternate Designs

None were considered.

### Benefits

Fixes syntax highlighting for class pattern.

### Possible Drawbacks

None

### Applicable Issues

Closes #167
