### PR TITLE
Fix enums with override methods

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -587,6 +587,26 @@
               {
                 'include': '#comments'
               }
+              # Represents enum's constant field with the code overrides
+              {
+                'begin': '(\\w+)\\s*({)'
+                'beginCaptures':
+                  '1':
+                    'name': 'constant.other.enum.java'
+                  '2':
+                    'name': 'punctuation.bracket.curly.java'
+                'end': '\\}'
+                'endCaptures':
+                  '0':
+                    'name': 'punctuation.bracket.curly.java'
+                'patterns': [
+                  {
+                    # Use #class-body, because the enum field overrides enum class body.
+                    # It is similar to inner class.
+                    'include': '#class-body'
+                  }
+                ]
+              }
               # Represents enum's constant field with constructor, e.g. `Test(123)`
               {
                 'begin': '(\\w+)\\s*(\\()'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -368,6 +368,48 @@ describe 'Java grammar', ->
     expect(lines[4][1]).toEqual value: 'BLUE', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'constant.other.enum.java']
     expect(lines[5][1]).toEqual value: '}', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java']
 
+  it 'tokenizes enums with method overrides', ->
+    lines = grammar.tokenizeLines '''
+      enum TYPES {
+        TYPE_A {
+          @Override
+          int func() {
+            return 1;
+          }
+        },
+        TYPE_B {
+          @Override
+          int func() {
+            return 2;
+          }
+        },
+        TYPE_DEFAULT;
+
+        int func() {
+          return 0;
+        }
+      }
+    '''
+
+    expect(lines[1][1]).toEqual value: 'TYPE_A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[1][3]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+    expect(lines[2][2]).toEqual value: 'Override', scopes: ['source.java', 'meta.enum.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
+    expect(lines[3][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[3][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[6][1]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+
+    expect(lines[7][1]).toEqual value: 'TYPE_B', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[7][3]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+    expect(lines[8][2]).toEqual value: 'Override', scopes: ['source.java', 'meta.enum.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
+    expect(lines[9][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[9][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[12][1]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+
+    expect(lines[13][1]).toEqual value: 'TYPE_DEFAULT', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+
+    expect(lines[15][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[15][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+
   it 'does not catastrophically backtrack when tokenizing large enums (regression)', ->
     # https://github.com/atom/language-java/issues/103
     # This test 'fails' if it runs for an absurdly long time without completing.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR extends support for enums and adds a pattern to handle enum's constant fields with method overrides. It is allowed to have such fields mixed with the previous two types that we have added.

The fix is fairly simple - adding another pattern to handle the case of enum field starting with `{` and ending with `}` similar to inner class. For that reason, I used `include: #class-body` instead of `include: #code`.

### Alternate Designs

None were considered, since it is fairly simple fix.

### Benefits

Fixes enum highlighting for enums with override methods.

### Possible Drawbacks

None. It only affects changes for enums.

### Applicable Issues

Closes #173 
