### PR TITLE
Add support for `final` in `catch` parameters

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1330,11 +1330,13 @@
                 'name': 'punctuation.catch.separator.java'
               }
               {
-                'match': '([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?'
+                'match': '(final)?\\s*([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?'
                 'captures':
                   '1':
-                    'name': 'storage.type.java'
+                    'name': 'storage.modifier.java'
                   '2':
+                    'name': 'storage.type.java'
+                  '3':
                     'name': 'variable.parameter.java'
               }
             ]

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1326,17 +1326,18 @@
                 'include': '#comments'
               }
               {
+                'include': '#storage-modifiers'
+              }
+              {
                 'match': '\\|'
                 'name': 'punctuation.catch.separator.java'
               }
               {
-                'match': '(final)?\\s*([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?'
+                'match': '([a-zA-Z$_][\\.a-zA-Z0-9$_]*)\\s*(\\w+)?'
                 'captures':
                   '1':
-                    'name': 'storage.modifier.java'
-                  '2':
                     'name': 'storage.type.java'
-                  '3':
+                  '2':
                     'name': 'variable.parameter.java'
               }
             ]

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2079,6 +2079,27 @@ describe 'Java grammar', ->
     expect(lines[2][20]).toEqual value: ')', scopes: scopes.concat ['meta.try.resources.java', 'punctuation.section.try.resources.end.bracket.round.java']
     expect(lines[2][22]).toEqual value: '{', scopes: scopes.concat ['punctuation.section.try.begin.bracket.curly.java']
 
+  it 'tokenizes storage modifier in catch block', ->
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        private void method() {
+          try {
+            // do something
+          } catch (final Exception1 ex) {
+            throw new Exception2();
+          }
+        }
+      }
+      '''
+
+    expect(lines[5][3]).toEqual value: 'catch', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'keyword.control.catch.java']
+    expect(lines[5][5]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[5][6]).toEqual value: 'final', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.modifier.java']
+    expect(lines[5][8]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[5][10]).toEqual value: 'ex', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'variable.parameter.java']
+    expect(lines[5][11]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.end.bracket.round.java']
+
   it 'tokenizes list of exceptions in catch block', ->
     lines = grammar.tokenizeLines '''
       class Test


### PR DESCRIPTION
### Description of the Change

The regex for the `catch` parameters currently does not support `final`, meaning that `final` is highlighted as a type. This change adds an optional group to account for the possibility of the Java `final` modifier.

### Alternate Designs

None, as prepending the existing regex is a simple change.

### Benefits

Correct syntax highlighting when `final` is within `catch` parameters

### Possible Drawbacks

None.

### Applicable Issues

None.