### PR TITLE
Add extends and implements to enums scope

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -571,6 +571,38 @@
     'name': 'meta.enum.java'
     'patterns': [
       {
+        'begin': '\\b(extends)\\b'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.extends.java'
+        'end': '(?={|\\bimplements\\b)'
+        'name': 'meta.definition.class.inherited.classes.java'
+        'patterns': [
+          {
+            'include': '#object-types-inherited'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+      {
+        'begin': '\\b(implements)\\b'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.implements.java'
+        'end': '(?={|\\bextends\\b)'
+        'name': 'meta.definition.class.implemented.interfaces.java'
+        'patterns': [
+          {
+            'include': '#object-types-inherited'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+      {
         'begin': '{'
         'beginCaptures':
           '0':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -410,6 +410,65 @@ describe 'Java grammar', ->
     expect(lines[15][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
     expect(lines[15][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
 
+  it 'tokenizes enums with extends and implements', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        enum Test1 extends Bclass, Cclass implements Din, Ein {
+        }
+
+        enum Test2 implements Din, Ein extends Bclass, Cclass {
+        }
+
+        enum Test3 extends SomeClass {
+        }
+
+        enum Test4 implements SomeInterface {
+        }
+
+        enum Test5 extends java.lang.SomeClass {
+        }
+
+        enum Test6 implements java.lang.SomeInterface {
+        }
+      }
+      '''
+
+    scopeStack = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.enum.java']
+
+    # Test1
+    expect(lines[1][5]).toEqual value: 'extends', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'storage.modifier.extends.java']
+    expect(lines[1][7]).toEqual value: 'Bclass', scopes: scopeStack.concat  ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+    expect(lines[1][10]).toEqual value: 'Cclass', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+    expect(lines[1][12]).toEqual value: 'implements', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'storage.modifier.implements.java']
+    expect(lines[1][14]).toEqual value: 'Din', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+    expect(lines[1][17]).toEqual value: 'Ein', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+
+    # Test2
+    expect(lines[4][5]).toEqual value: 'implements', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'storage.modifier.implements.java']
+    expect(lines[4][7]).toEqual value: 'Din', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+    expect(lines[4][10]).toEqual value: 'Ein', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+    expect(lines[4][12]).toEqual value: 'extends', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'storage.modifier.extends.java']
+    expect(lines[4][14]).toEqual value: 'Bclass', scopes: scopeStack.concat  ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+    expect(lines[4][17]).toEqual value: 'Cclass', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+
+    # Test3
+    expect(lines[7][5]).toEqual value: 'extends', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'storage.modifier.extends.java']
+    expect(lines[7][7]).toEqual value: 'SomeClass', scopes: scopeStack.concat  ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+
+    # Test4
+    expect(lines[10][5]).toEqual value: 'implements', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'storage.modifier.implements.java']
+    expect(lines[10][7]).toEqual value: 'SomeInterface', scopes: scopeStack.concat  ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+
+    # Test5
+    # TODO ' java.lang.' is highlighted as a single block for some reason, same for the class
+    expect(lines[13][5]).toEqual value: 'extends', scopes: scopeStack.concat ['meta.definition.class.inherited.classes.java', 'storage.modifier.extends.java']
+    expect(lines[13][7]).toEqual value: 'SomeClass', scopes: scopeStack.concat  ['meta.definition.class.inherited.classes.java', 'entity.other.inherited-class.java']
+
+    # Test6
+    # TODO ' java.lang.' is highlighted as a single block for some reason, same for the class
+    expect(lines[16][5]).toEqual value: 'implements', scopes: scopeStack.concat ['meta.definition.class.implemented.interfaces.java', 'storage.modifier.implements.java']
+    expect(lines[16][7]).toEqual value: 'SomeInterface', scopes: scopeStack.concat  ['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java']
+
   it 'does not catastrophically backtrack when tokenizing large enums (regression)', ->
     # https://github.com/atom/language-java/issues/103
     # This test 'fails' if it runs for an absurdly long time without completing.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds `extends` and `implements` to `enums` scope. Currently we have enum scope separate from class and interface, because of the complexity of enum's representations, though we did not migrate `extends` and `implements` to the enum. This work fixes the issue by copying those blocks of code from class scope and adding them to enum scope with some minor changes.

### Alternate Designs

None were considered.

### Benefits

Fixes a regression for enum's `extends` and `implements`.

### Possible Drawbacks

This patch introduces a bit of code duplication between class and enum, mostly because of the separation of those scopes.

### Applicable Issues

Closes #185 
