### PR TITLE
Fix annotation scope and handle spaces between @ and annotation name

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -129,13 +129,13 @@
   'annotations':
     'patterns': [
       {
-        'begin': '((@)[^\\s(]+)(\\()'
+        'begin': '((@)\\s*([^\\s(]+))(\\()'
         'beginCaptures':
-          '1':
-            'name': 'storage.type.annotation.java'
           '2':
             'name': 'punctuation.definition.annotation.java'
           '3':
+            'name': 'storage.type.annotation.java'
+          '4':
             'name': 'punctuation.definition.annotation-arguments.begin.bracket.round.java'
         'end': '\\)'
         'endCaptures':
@@ -157,7 +157,7 @@
         ]
       }
       {
-        'match': '(@)(interface)\\s+(\\w*)|((@)\\w*)'
+        'match': '(@)(interface)\\s+(\\w*)|((@)\\s*(\\w+))'
         'name': 'meta.declaration.annotation.java'
         'captures':
           '1':
@@ -166,10 +166,10 @@
             'name': 'storage.modifier.java'
           '3':
             'name': 'storage.type.annotation.java'
-          '4':
-            'name': 'storage.type.annotation.java'
           '5':
             'name': 'punctuation.definition.annotation.java'
+          '6':
+            'name': 'storage.type.annotation.java'
       }
     ]
   'anonymous-block-and-instance-initializer':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2568,10 +2568,10 @@ describe 'Java grammar', ->
       public @interface Test {}
       '''
 
-    expect(lines[0][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java', 'punctuation.definition.annotation.java']
+    expect(lines[0][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation.java']
     expect(lines[0][1]).toEqual value: 'Annotation', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
 
-    expect(lines[1][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java', 'punctuation.definition.annotation.java']
+    expect(lines[1][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation.java']
     expect(lines[1][1]).toEqual value: 'Table', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
     expect(lines[1][2]).toEqual value: '(', scopes: ['source.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation-arguments.begin.bracket.round.java']
     expect(lines[1][3]).toEqual value: 'key', scopes: ['source.java', 'meta.declaration.annotation.java', 'constant.other.key.java']
@@ -2581,10 +2581,10 @@ describe 'Java grammar', ->
     expect(lines[1][9]).toEqual value: '"', scopes: ['source.java', 'meta.declaration.annotation.java',  'string.quoted.double.java', 'punctuation.definition.string.end.java']
     expect(lines[1][10]).toEqual value: ')', scopes: ['source.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation-arguments.end.bracket.round.java']
 
-    expect(lines[3][1]).toEqual value: '@', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java', 'punctuation.definition.annotation.java']
+    expect(lines[3][1]).toEqual value: '@', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation.java']
     expect(lines[3][2]).toEqual value: 'Override', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
 
-    expect(lines[4][1]).toEqual value: '@', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java', 'punctuation.definition.annotation.java']
+    expect(lines[4][1]).toEqual value: '@', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation.java']
     expect(lines[4][2]).toEqual value: 'Column', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
     expect(lines[4][3]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation-arguments.begin.bracket.round.java']
     expect(lines[4][4]).toEqual value: 'true', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java', 'constant.language.java']
@@ -2602,3 +2602,24 @@ describe 'Java grammar', ->
     expect(lines[8][2]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation.java', 'punctuation.definition.annotation.java']
     expect(lines[8][3]).toEqual value: 'interface', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.modifier.java']
     expect(lines[8][5]).toEqual value: 'Test', scopes: ['source.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
+
+  it 'tokenizes annotations with spaces', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        @ Override
+        public void func1() {
+        }
+
+        @ Message("message")
+        public void func2() {
+        }
+      }
+      '''
+
+    scopes = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java']
+    # expect(lines[2][1]).toEqual value: 'try', scopes: scopes.concat ['keyword.control.try.java']
+    expect(lines[1][1]).toEqual value: '@', scopes: scopes.concat(['punctuation.definition.annotation.java'])
+    expect(lines[1][3]).toEqual value: 'Override', scopes: scopes.concat(['storage.type.annotation.java'])
+    expect(lines[5][1]).toEqual value: '@', scopes: scopes.concat(['punctuation.definition.annotation.java'])
+    expect(lines[5][3]).toEqual value: 'Message', scopes: scopes.concat(['storage.type.annotation.java'])
+    expect(lines[5][6]).toEqual value: 'message', scopes: scopes.concat(['string.quoted.double.java'])

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2617,7 +2617,6 @@ describe 'Java grammar', ->
       '''
 
     scopes = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.declaration.annotation.java']
-    # expect(lines[2][1]).toEqual value: 'try', scopes: scopes.concat ['keyword.control.try.java']
     expect(lines[1][1]).toEqual value: '@', scopes: scopes.concat(['punctuation.definition.annotation.java'])
     expect(lines[1][3]).toEqual value: 'Override', scopes: scopes.concat(['storage.type.annotation.java'])
     expect(lines[5][1]).toEqual value: '@', scopes: scopes.concat(['punctuation.definition.annotation.java'])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes the issue of scope and highlighting being invalid when space is inserted between `@` and annotation name, e.g. `@ Annotation` as opposed to `@Annotation`. We basically need to insert `\\s*` in the correct place. However, I observed that patterns are invalid in a sense that they capture `@` as part of annotation name scope. 

So I also fixed the scope of annotations so that `storage.type.annotation.java` does not capture `@`. They both have parent scope `meta.declaration.annotation.java`. This makes them similar to `@interface`.

### Alternate Designs

None were considered.

### Benefits

Fixes issue when using spaces in annotations.

### Possible Drawbacks

None

### Applicable Issues

Closes #194 
