### PR TITLE
Fix whitespace issue in variable definition

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1425,9 +1425,11 @@
           |
           (?>(\\w+\\.)*[A-Z]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
+        \\s*
         (
           <[\\w<>,\\.?\\s\\[\\]]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`
         )?
+        \\s*
         (
           (\\[\\])* # int[][]
         )?

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1751,6 +1751,8 @@ describe 'Java grammar', ->
         String[] primitiveArray;
         private Foo<int[]> hi;
         Foo<int[]> hi;
+        String [] var1;
+        List <String> var2;
       }
       '''
 
@@ -1843,6 +1845,17 @@ describe 'Java grammar', ->
     expect(lines[15][4]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[15][5]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
     expect(lines[15][6]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+
+    expect(lines[16][1]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.object.array.java']
+    expect(lines[16][3]).toEqual value: '[', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[16][4]).toEqual value: ']', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.square.java']
+    expect(lines[16][6]).toEqual value: 'var1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
+
+    expect(lines[17][1]).toEqual value: 'List', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[17][3]).toEqual value: '<', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[17][4]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'storage.type.generic.java']
+    expect(lines[17][5]).toEqual value: '>', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'punctuation.bracket.angle.java']
+    expect(lines[17][7]).toEqual value: 'var2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.definition.variable.java', 'variable.other.definition.java']
 
   it 'tokenizes class fields with complex definitions', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes an issue when inserting a whitespaces after storage type in variable definition would break highlighting.

For example,

```java
class A {
  String [] var1;
  int [] var2;
  List <String> var3;
}
```
Variables `var1`, `var2`, and `var3` would not be scoped properly. I patched `variables` scope by inserting `\s*` to handle whitespaces for generics and arrays.

### Alternate Designs

Adding a whitespace inside the matching pattern, but it seemed a bit odd to have it, plus, there was already a precedent to use it outside of matching groups.

### Benefits

Fixes the highlighting.

### Possible Drawbacks

None.

### Applicable Issues

#196 
