### PR TITLE
Update regex for `anonymous-classes-and-new` end

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -191,7 +191,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\)|,|:|}|\\+)'
+    'end': '(?=;|\\)|,|:|}|\\+|\\-|\\*|\\/|%|!|&|\\||=)'
     'patterns': [
       {
         'include': '#comments'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1708,6 +1708,33 @@ describe 'Java grammar', ->
     expect(lines[6][0]).toEqual value: '}', scopes: ['source.java', 'meta.inner-class.java', 'punctuation.section.inner-class.end.bracket.curly.java']
     expect(lines[6][1]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
+    # See issue https://github.com/atom/language-java/issues/192
+    lines = grammar.tokenizeLines '''
+      class A {
+        void func() {
+          long a = new Date().getTime() + start.getTime();
+          long b = new Date().getTime() - start.getTime();
+          long c = new Date().getTime() * start.getTime();
+          long d = new Date().getTime() / start.getTime();
+          long e = new Date().getTime() & start.getTime();
+          long f = new Date().getTime() | start.getTime();
+          boolean g = new Date().getTime() == start.getTime();
+          boolean h = new Date().getTime() != start.getTime();
+        }
+      }
+      '''
+
+    expected = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'variable.other.object.java']
+
+    expect(lines[2][19]).toEqual value: 'start', scopes: expected
+    expect(lines[3][19]).toEqual value: 'start', scopes: expected
+    expect(lines[4][19]).toEqual value: 'start', scopes: expected
+    expect(lines[5][19]).toEqual value: 'start', scopes: expected
+    expect(lines[6][19]).toEqual value: 'start', scopes: expected
+    expect(lines[7][19]).toEqual value: 'start', scopes: expected
+    expect(lines[8][19]).toEqual value: 'start', scopes: expected
+    expect(lines[9][19]).toEqual value: 'start', scopes: expected
+
   it 'tokenizes the `instanceof` operator', ->
     {tokens} = grammar.tokenizeLine 'instanceof'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR updates end pattern in `anonymous-classes-and-new` and patches variable scope after constructor, see example below:
```java
class A {
  void func() {
    long a = new Date().getTime() + start.getTime();
    long b = new Date().getTime() - start.getTime();
    long c = new Date().getTime() * start.getTime();
    long d = new Date().getTime() / start.getTime();
    long e = new Date().getTime() & start.getTime();
    long f = new Date().getTime() | start.getTime();
    boolean g = new Date().getTime() == start.getTime();
    boolean h = new Date().getTime() != start.getTime();
  }
}
```

Note that this is not exhaustive pattern, but should fix most of the cases.

### Alternate Designs

None were considered. Note that this issue will not exist once we switch to tree-sitter.

### Benefits

Enables correct scope in the case mentioned above.

### Possible Drawbacks

Could fix some other highlighting case that is not captured by our tests.

### Applicable Issues

Closes #192
