### PR TITLE
Parse class identifier containing a dollar char

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -243,7 +243,7 @@
       }
     ]
   'class':
-    'begin': '(?=\\w?[\\w\\s]*\\b(?:class|(?<!@)interface|enum)\\s+\\w+)'
+    'begin': '(?=\\w?[\\w\\s]*\\b(?:class|(?<!@)interface|enum)\\s+[\\w$]+)'
     'end': '}'
     'endCaptures':
       '0':
@@ -265,7 +265,7 @@
             'name': 'storage.modifier.java'
           '2':
             'name': 'entity.name.type.class.java'
-        'match': '(class|(?<!@)interface|enum)\\s+(\\w+)'
+        'match': '(class|(?<!@)interface|enum)\\s+([\\w$]+)'
         'name': 'meta.class.identifier.java'
       }
       {

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -226,6 +226,10 @@ describe 'Java grammar', ->
         Testclass test1 = null;
         TestClass test2 = null;
       }
+
+      class A$B {
+        int a;
+      }
     '''
 
     expect(lines[0][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
@@ -236,6 +240,8 @@ describe 'Java grammar', ->
     expect(lines[8][2]).toEqual value: 'Aclass', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
     expect(lines[13][1]).toEqual value: 'Testclass', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
     expect(lines[14][1]).toEqual value: 'TestClass', scopes: ['source.java', 'meta.definition.variable.java', 'storage.type.java']
+    expect(lines[17][0]).toEqual value: 'class', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'storage.modifier.java']
+    expect(lines[17][2]).toEqual value: 'A$B', scopes: ['source.java', 'meta.class.java', 'meta.class.identifier.java', 'entity.name.type.class.java']
 
   it 'tokenizes enums', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Description of the Change

`\w` equals to`A-Za-z0-9_`.  `$` is not contained, which is allowed to be part of the class identifier. 

### Alternate Designs

None were considered.

### Benefits

Can highlight class name containing `$`.

### Possible Drawbacks

I don't see any. 

### Applicable Issues

https://github.com/redhat-developer/vscode-java/issues/299
<img width="436" alt="Screen Shot 2019-11-21 at 3 09 36 PM" src="https://user-images.githubusercontent.com/2351748/69315249-08ff2c80-0c71-11ea-8564-9181f290d696.png">
