### PR TITLE
Comments should not end 'keyword.control.new.java'

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -191,7 +191,7 @@
     'beginCaptures':
       '0':
         'name': 'keyword.control.new.java'
-    'end': '(?=;|\\)|,|:|}|\\+|\\-|\\*|\\/|%|!|&|\\||=)'
+    'end': '(?=;|\\)|,|:|}|\\+|\\-|\\*|\\/(?!\\/|\\*)|%|!|&|\\||=)'
     'patterns': [
       {
         'include': '#comments'

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1682,6 +1682,21 @@ describe 'Java grammar', ->
     expect(tokens[6]).toEqual value: 'Point', scopes: ['source.java', 'meta.function-call.java', 'entity.name.function.java']
     expect(tokens[9]).toEqual value: ';', scopes: ['source.java', 'punctuation.terminator.java']
 
+    {tokens} = grammar.tokenizeLine 'new Point() /* JPanel() */ { };'
+
+    expect(tokens[10]).toEqual value: '{', scopes: ['source.java', 'meta.inner-class.java', 'punctuation.section.inner-class.begin.bracket.curly.java']
+    expect(tokens[11]).toEqual value: ' ', scopes: ['source.java', 'meta.inner-class.java']
+    expect(tokens[12]).toEqual value: '}', scopes: ['source.java', 'meta.inner-class.java', 'punctuation.section.inner-class.end.bracket.curly.java']
+
+    lines = grammar.tokenizeLines '''
+      new Point() // JPanel()
+      { }
+      '''
+
+    expect(lines[1][0]).toEqual value: '{', scopes: ['source.java', 'meta.inner-class.java', 'punctuation.section.inner-class.begin.bracket.curly.java']
+    expect(lines[1][1]).toEqual value: ' ', scopes: ['source.java', 'meta.inner-class.java']
+    expect(lines[1][2]).toEqual value: '}', scopes: ['source.java', 'meta.inner-class.java', 'punctuation.section.inner-class.end.bracket.curly.java']
+
     lines = grammar.tokenizeLines '''
       map.put(key,
         new Value(value)
@@ -2563,7 +2578,7 @@ describe 'Java grammar', ->
     expect(lines[9][12]).toEqual value: 'String', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'entity.name.type.class.java']
     expect(lines[9][13]).toEqual value: '#', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java']
     expect(lines[9][14]).toEqual value: 'chars()', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'comment.block.javadoc.java', 'variable.parameter.java']
-    
+
 
   it 'tokenizes class-body block initializer', ->
     lines = grammar.tokenizeLines '''


### PR DESCRIPTION
### Description of the Change

Currently, the divide operator ('/') will end 'keyword.control.new.java' scope. But ('/') could also be the beginning of a comment, and it should not end the scope.

### Alternate Designs

No alternative considered.

### Benefits

Comment would not affect the highlighting of inner class, as described in #209.

### Possible Drawbacks

Nothing as far as I know.

### Applicable Issues

Fix #209 
