### PR TITLE
More robust enum field's pattern logic

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -619,8 +619,7 @@
               {
                 'include': '#comments'
               }
-              # Represents enum's constant field entry
-              {
+              { # Represents enum's constant field entry
                 'begin': '\\b(\\w+)\\b'
                 'beginCaptures':
                   '1':
@@ -636,7 +635,20 @@
                   {
                     'include': '#comments'
                   }
-                  { # Represents enum's constant field with the code overrides
+                  { # Represents enum's constructor, e.g. `("1", 123)` in `Test("1", 123)`
+                    'begin': '\\(',
+                    'beginCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.round.java'
+                    'end': '\\)'
+                    'endCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.round.java'
+                    'patterns': [
+                      'include': '#code'
+                    ]
+                  }
+                  { # Represents enum's body with code overrides
                     'begin': '{',
                     'beginCaptures':
                       '0':
@@ -649,19 +661,6 @@
                       # Use #class-body, because the enum field overrides enum class body.
                       # It is similar to inner class.
                       'include': '#class-body'
-                    ]
-                  }
-                  { # Represents enum's constant field with constructor, e.g. `Test(123)`
-                    'begin': '\\(',
-                    'beginCaptures':
-                      '0':
-                        'name': 'punctuation.bracket.round.java'
-                    'end': '\\)'
-                    'endCaptures':
-                      '0':
-                        'name': 'punctuation.bracket.round.java'
-                    'patterns': [
-                      'include': '#code'
                     ]
                   }
                 ]

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -619,48 +619,52 @@
               {
                 'include': '#comments'
               }
-              # Represents enum's constant field with the code overrides
+              # Represents enum's constant field entry
               {
-                'begin': '(\\w+)\\s*({)'
+                'begin': '\\b(\\w+)\\b'
                 'beginCaptures':
                   '1':
                     'name': 'constant.other.enum.java'
-                  '2':
-                    'name': 'punctuation.bracket.curly.java'
-                'end': '\\}'
+                'end': '(,)|(?=;|})'
                 'endCaptures':
-                  '0':
-                    'name': 'punctuation.bracket.curly.java'
-                'patterns': [
-                  {
-                    # Use #class-body, because the enum field overrides enum class body.
-                    # It is similar to inner class.
-                    'include': '#class-body'
-                  }
-                ]
-              }
-              # Represents enum's constant field with constructor, e.g. `Test(123)`
-              {
-                'begin': '(\\w+)\\s*(\\()'
-                'beginCaptures':
                   '1':
-                    'name': 'constant.other.enum.java'
-                  '2':
-                    'name': 'punctuation.bracket.round.java'
-                'end': '\\)'
-                'endCaptures':
-                  '0':
-                    'name': 'punctuation.bracket.round.java'
+                    'name': 'punctuation.separator.delimiter.java'
                 'patterns': [
                   {
-                    'include': '#code'
+                    'include': '#comments-javadoc'
+                  }
+                  {
+                    'include': '#comments'
+                  }
+                  { # Represents enum's constant field with the code overrides
+                    'begin': '{',
+                    'beginCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.curly.java'
+                    'end': '}'
+                    'endCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.curly.java'
+                    'patterns': [
+                      # Use #class-body, because the enum field overrides enum class body.
+                      # It is similar to inner class.
+                      'include': '#class-body'
+                    ]
+                  }
+                  { # Represents enum's constant field with constructor, e.g. `Test(123)`
+                    'begin': '\\(',
+                    'beginCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.round.java'
+                    'end': '\\)'
+                    'endCaptures':
+                      '0':
+                        'name': 'punctuation.bracket.round.java'
+                    'patterns': [
+                      'include': '#code'
+                    ]
                   }
                 ]
-              }
-              # Represents enum's constant field, e.g. `Test`
-              {
-                'match': '\\b\\w+\\b'
-                'name': 'constant.other.enum.java'
               }
             ]
           }

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -416,6 +416,70 @@ describe 'Java grammar', ->
     expect(lines[15][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
     expect(lines[15][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
 
+  it 'tokenizes enums with method overrides and constructor', ->
+    lines = grammar.tokenizeLines '''
+      enum TYPES {
+        TYPE_A("1", 1) {
+          @Override
+          int func() {
+            return 1;
+          }
+        },
+        TYPE_B("2", 2)
+        {
+          @Override
+          int func() {
+            return 2;
+          }
+        },
+        TYPE_DEFAULT("3", 3);
+
+        String label;
+        int value;
+
+        TYPES(String label, int value) {
+          this.label = label;
+          this.value = value;
+        }
+
+        int func() {
+          return 0;
+        }
+      }
+    '''
+
+    expect(lines[1][1]).toEqual value: 'TYPE_A', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[1][2]).toEqual value: '(', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[1][3]).toEqual value: '"', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java', 'punctuation.definition.string.begin.java']
+    expect(lines[1][4]).toEqual value: '1', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java']
+    expect(lines[1][5]).toEqual value: '"', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java', 'punctuation.definition.string.end.java']
+    expect(lines[1][6]).toEqual value: ',', scopes: ['source.java', 'meta.enum.java', 'punctuation.separator.delimiter.java']
+    expect(lines[1][8]).toEqual value: '1', scopes: ['source.java', 'meta.enum.java', 'constant.numeric.decimal.java']
+    expect(lines[1][9]).toEqual value: ')', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[1][11]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+    expect(lines[2][2]).toEqual value: 'Override', scopes: ['source.java', 'meta.enum.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
+    expect(lines[3][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[3][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[6][1]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+
+    expect(lines[7][1]).toEqual value: 'TYPE_B', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+    expect(lines[7][2]).toEqual value: '(', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[7][3]).toEqual value: '"', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java', 'punctuation.definition.string.begin.java']
+    expect(lines[7][4]).toEqual value: '2', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java']
+    expect(lines[7][5]).toEqual value: '"', scopes: ['source.java', 'meta.enum.java', 'string.quoted.double.java', 'punctuation.definition.string.end.java']
+    expect(lines[7][6]).toEqual value: ',', scopes: ['source.java', 'meta.enum.java', 'punctuation.separator.delimiter.java']
+    expect(lines[7][8]).toEqual value: '2', scopes: ['source.java', 'meta.enum.java', 'constant.numeric.decimal.java']
+    expect(lines[7][9]).toEqual value: ')', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.round.java']
+    expect(lines[8][1]).toEqual value: '{', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java'] # Begin bracket placed at new line
+    expect(lines[9][2]).toEqual value: 'Override', scopes: ['source.java', 'meta.enum.java', 'meta.declaration.annotation.java', 'storage.type.annotation.java']
+    expect(lines[10][1]).toEqual value: 'int', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.return-type.java', 'storage.type.primitive.java']
+    expect(lines[10][3]).toEqual value: 'func', scopes: ['source.java', 'meta.enum.java', 'meta.method.java', 'meta.method.identifier.java', 'entity.name.function.java']
+    expect(lines[13][1]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.bracket.curly.java']
+
+    expect(lines[14][1]).toEqual value: 'TYPE_DEFAULT', scopes: ['source.java', 'meta.enum.java', 'constant.other.enum.java']
+
+    expect(lines[27][0]).toEqual value: '}', scopes: ['source.java', 'meta.enum.java', 'punctuation.section.enum.end.bracket.curly.java'] # Test that enum scope correctly ends
+
   it 'tokenizes enums with extends and implements', ->
     lines = grammar.tokenizeLines '''
       class A {


### PR DESCRIPTION
### Description of the Change

The original logic uses three different patterns to match an enum constant field. This PR replaces them with a two-scope uniform pattern.

### Alternate Designs

To solve #211, an alternative would be to add another to match (constructor + code overrides), but it introduces too much duplicate code, and it still cannot highlight correctly when '{' is placed at new line.

### Benefits

* Can correctly highlight with all possible combinations of constructor & code overrides
* Can correctly highlight when '{' is placed at new line or with a comment in between
* Patterns are more neat and uniform

### Possible Drawbacks

* Undetected possible regression issues

### Applicable Issues

Fix #211 
Fix redhat-developer/vscode-java#974
