### PR TITLE
Relax the too restrictive begin expression for catch block

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1334,9 +1334,9 @@
           }
         ]
       }
-      # catch block (with "parameters")
+      # catch block
       {
-        'begin': '\\b(catch)\\b\\s*(?=\\(\\s*[^\\s]+\\s*[^)]+\\))'
+        'begin': '\\b(catch)\\b'
         'beginCaptures':
           '1':
             'name': 'keyword.control.catch.java'
@@ -1346,6 +1346,9 @@
             'name': 'punctuation.section.catch.end.bracket.curly.java'
         'name': 'meta.catch.java'
         'patterns': [
+          {
+            'include': '#comments'
+          }
           {
             'begin': '\\('
             'beginCaptures':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2341,6 +2341,33 @@ describe 'Java grammar', ->
     expect(lines[5][12]).toEqual value: 'err', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'variable.parameter.java']
     expect(lines[5][13]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.end.bracket.round.java']
 
+    lines = grammar.tokenizeLines '''
+      class Test
+      {
+        private void method() {
+          try {
+            // do something
+          } catch // this is a catch
+          (Exception1 |
+              Exception2
+            | Exception3 err) {
+            throw new Exception3();
+          }
+        }
+      }
+      '''
+
+    expect(lines[5][3]).toEqual value: 'catch', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'keyword.control.catch.java']
+    expect(lines[5][5]).toEqual value: '//', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java']
+    expect(lines[6][1]).toEqual value: '(', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.begin.bracket.round.java']
+    expect(lines[6][2]).toEqual value: 'Exception1', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[6][4]).toEqual value: '|', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'punctuation.catch.separator.java']
+    expect(lines[7][1]).toEqual value: 'Exception2', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[8][1]).toEqual value: '|', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'punctuation.catch.separator.java']
+    expect(lines[8][3]).toEqual value: 'Exception3', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'storage.type.java']
+    expect(lines[8][5]).toEqual value: 'err', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'meta.catch.parameters.java', 'variable.parameter.java']
+    expect(lines[8][6]).toEqual value: ')', scopes: ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'meta.catch.java', 'punctuation.definition.parameters.end.bracket.round.java']
+
   it 'tokenizes list of exceptions in method throws clause', ->
     lines = grammar.tokenizeLines '''
       class Test {


### PR DESCRIPTION
### Description of the Change

Relax the too restrictive begin expression for catch block for following reasons:

* The begin pattern is not suitable for dealing with multi-line pattern.
* any comments between `catch` and `(` would also break the highlighting.

Leave the catch keywork be would just be fine, since syntax highlighting should only be responsible for happy path.

### Alternate Designs

Any other design would introduce new complexity.

### Benefits

* Can correctly highlight when caught exceptions are split in multiple lines
* Can correctly highlight when '(' is placed in a new line after `catch`
* Can correctly highlight when there is comment between `catch` and '('
* Reduces the complexity

### Possible Drawbacks

More like a `right` hightlight for wrong syntax in code.

### Applicable Issues

Fix #205 
FIx https://github.com/microsoft/vscode-java-pack/issues/259