### PR TITLE
Support for Java 14's Record

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -418,6 +418,9 @@
         'include': '#class'
       }
       {
+        'include': '#record' # Java 14
+      }
+      {
         'include': '#anonymous-block-and-instance-initializer'
       }
       {
@@ -1254,6 +1257,121 @@
             'name': 'punctuation.separator.period.java'
           '2':
             'name': 'invalid.illegal.identifier.java'
+      }
+    ]
+  # Java 14 Record
+  # see spec http://openjdk.java.net/jeps/359
+  'record':
+    'begin': '(?=\\w?[\\w\\s]*\\b(?:record)\\s+[\\w$]+)'
+    'end': '}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.class.end.bracket.curly.java'
+    'name': 'meta.record.java'
+    'patterns': [
+      {
+        'include': '#storage-modifiers'
+      }
+      {
+        'include': '#generics'
+      }
+      {
+        'include': '#comments'
+      }
+      {
+        'begin': '(record)\\s+([\\w$]+)(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.java'
+          '2':
+            'name': 'entity.name.type.record.java'
+          '3':
+            'name': 'punctuation.definition.parameters.begin.bracket.round.java'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.parameters.end.bracket.round.java'
+        'name': 'meta.record.identifier.java'
+        'patterns': [
+          {
+            'include': '#code'
+          }
+        ]
+      }
+      {
+        'begin': '(implements)\\s'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.implements.java'
+        'end': '(?=\\s*\\{)' # by design, records cannot extend any other class
+        'name': 'meta.definition.class.implemented.interfaces.java'
+        'patterns': [
+          {
+            'include': '#object-types-inherited'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+      {
+        'include': '#record-body'
+      }
+    ]
+  'record-body':
+    'begin': '{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.class.begin.bracket.curly.java'
+    'end': '(?=})'
+    'name': 'meta.record.body.java'
+    'patterns': [
+      {
+        'include': '#record-constructor'
+      }
+      {
+        'include': '#class-body'
+      }
+    ]
+  'record-constructor':
+    'begin': '(?!new)(?=[\\w<].*\\s+)(?=([^\\(=/]|/(?!/))+(?={))'
+    'end': '(})|(?=;)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.method.end.bracket.curly.java'
+    'name': 'meta.method.java'
+    'patterns': [
+      {
+        'include': '#storage-modifiers'
+      }
+      {
+        'begin': '(\\w+)'
+        'beginCaptures':
+          '1':
+            'name': 'entity.name.function.java'
+        'end': '(?=\\s*{)'
+        'name': 'meta.method.identifier.java'
+        'patterns': [
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+      {
+        'include': '#comments'
+      }
+      {
+        'begin': '{'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.method.begin.bracket.curly.java'
+        'end': '(?=})'
+        'contentName': 'meta.method.body.java'
+        'patterns': [
+          {
+            'include': '#code'
+          }
+        ]
       }
     ]
   'static-initializer':

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1279,13 +1279,19 @@
         'include': '#comments'
       }
       {
-        'begin': '(record)\\s+([\\w$]+)(\\()'
+        'begin': '(record)\\s+([\\w$]+)(<[\\w$]+>)?(\\()'
         'beginCaptures':
           '1':
             'name': 'storage.modifier.java'
           '2':
             'name': 'entity.name.type.record.java'
           '3':
+            'patterns': [
+              {
+                'include': '#generics'
+              }
+            ]
+          '4':
             'name': 'punctuation.definition.parameters.begin.bracket.round.java'
         'end': '\\)'
         'endCaptures':

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2974,7 +2974,6 @@ describe 'Java grammar', ->
     lines = grammar.tokenizeLines '''
       record Point() {}
     '''
-    # console.log(JSON.stringify(lines, null, 2))
     recordScopes = ['source.java', 'meta.record.java']
     expect(lines[0][0]).toEqual value: 'record', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
     expect(lines[0][2]).toEqual value: 'Point', scopes: recordScopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
@@ -3000,6 +2999,23 @@ describe 'Java grammar', ->
     expect(lines[0][15]).toEqual value: 'IB', scopes: recordScopes.concat(['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java'])
     expect(lines[0][17]).toEqual value: '{', scopes: recordScopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
     expect(lines[0][18]).toEqual value: '}', scopes: recordScopes.concat(['punctuation.section.class.end.bracket.curly.java'])
+
+  it 'tokenizes Java 14 record with generic types as parameters', ->
+    lines = grammar.tokenizeLines '''
+        public record Point<T>(T x) { }
+      '''
+    recordScopes = ['source.java', 'meta.record.java']
+    expect(lines[0][0]).toEqual value: 'public', scopes: recordScopes.concat(['storage.modifier.java'])
+    expect(lines[0][2]).toEqual value: 'record', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
+    expect(lines[0][4]).toEqual value: 'Point', scopes: recordScopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
+    expect(lines[0][5]).toEqual value: '<', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.bracket.angle.java'])
+    expect(lines[0][6]).toEqual value: 'T', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.type.generic.java'])
+    expect(lines[0][7]).toEqual value: '>', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.bracket.angle.java'])
+    expect(lines[0][8]).toEqual value: '(', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java'])
+    expect(lines[0][9]).toEqual value: 'T', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.type.java'])
+    expect(lines[0][11]).toEqual value: ')', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
+    expect(lines[0][13]).toEqual value: '{', scopes: recordScopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
+    expect(lines[0][15]).toEqual value: '}', scopes: recordScopes.concat(['punctuation.section.class.end.bracket.curly.java'])
 
   it 'tokenizes Java 14 record construtor', ->
     lines = grammar.tokenizeLines '''

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -2969,3 +2969,80 @@ describe 'Java grammar', ->
     expect(lines[1][4]).toEqual value: 'interface', scopes: scopes.concat(['meta.declaration.annotation.java', 'storage.modifier.java'])
     expect(lines[2][1]).toEqual value: '//', scopes: scopes.concat(['comment.line.double-slash.java', 'punctuation.definition.comment.java'])
     expect(lines[3][5]).toEqual value: 'func', scopes: scopes.concat(['meta.function-call.java', 'entity.name.function.java'])
+
+  it 'tokenizes Java 14 records', ->
+    lines = grammar.tokenizeLines '''
+      record Point() {}
+    '''
+    # console.log(JSON.stringify(lines, null, 2))
+    recordScopes = ['source.java', 'meta.record.java']
+    expect(lines[0][0]).toEqual value: 'record', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
+    expect(lines[0][2]).toEqual value: 'Point', scopes: recordScopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
+    expect(lines[0][3]).toEqual value: '(', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java'])
+    expect(lines[0][4]).toEqual value: ')', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
+    expect(lines[0][6]).toEqual value: '{', scopes: recordScopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
+    expect(lines[0][7]).toEqual value: '}', scopes: recordScopes.concat(['punctuation.section.class.end.bracket.curly.java'])
+
+  it 'tokenizes Java 14 record implementing other interfaces', ->
+    lines = grammar.tokenizeLines '''
+      public record Point(int x) implements IA, IB {}
+    '''
+    recordScopes = ['source.java', 'meta.record.java']
+    expect(lines[0][0]).toEqual value: 'public', scopes: recordScopes.concat(['storage.modifier.java'])
+    expect(lines[0][2]).toEqual value: 'record', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
+    expect(lines[0][4]).toEqual value: 'Point', scopes: recordScopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
+    expect(lines[0][5]).toEqual value: '(', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java'])
+    expect(lines[0][6]).toEqual value: 'int', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.type.primitive.java'])
+    expect(lines[0][8]).toEqual value: ')', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
+    expect(lines[0][10]).toEqual value: 'implements', scopes: recordScopes.concat(['meta.definition.class.implemented.interfaces.java', 'storage.modifier.implements.java'])
+    expect(lines[0][12]).toEqual value: 'IA', scopes: recordScopes.concat(['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java'])
+    expect(lines[0][13]).toEqual value: ',', scopes: recordScopes.concat(['meta.definition.class.implemented.interfaces.java', 'punctuation.separator.delimiter.java'])
+    expect(lines[0][15]).toEqual value: 'IB', scopes: recordScopes.concat(['meta.definition.class.implemented.interfaces.java', 'entity.other.inherited-class.java'])
+    expect(lines[0][17]).toEqual value: '{', scopes: recordScopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
+    expect(lines[0][18]).toEqual value: '}', scopes: recordScopes.concat(['punctuation.section.class.end.bracket.curly.java'])
+
+  it 'tokenizes Java 14 record construtor', ->
+    lines = grammar.tokenizeLines '''
+      public record Point(int x, int y) {
+        public Point {
+          // validation
+        }
+        private void foo() { }
+      }
+    '''
+    recordScopes = ['source.java', 'meta.record.java']
+    expect(lines[0][0]).toEqual value: 'public', scopes: recordScopes.concat(['storage.modifier.java'])
+    expect(lines[0][2]).toEqual value: 'record', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
+    expect(lines[0][4]).toEqual value: 'Point', scopes: recordScopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
+    expect(lines[0][5]).toEqual value: '(', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java'])
+    expect(lines[0][6]).toEqual value: 'int', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.type.primitive.java'])
+    expect(lines[0][8]).toEqual value: ',', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.separator.delimiter.java'])
+    expect(lines[0][10]).toEqual value: 'int', scopes: recordScopes.concat(['meta.record.identifier.java', 'storage.type.primitive.java'])
+    expect(lines[0][12]).toEqual value: ')', scopes: recordScopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
+    expect(lines[0][14]).toEqual value: '{', scopes: recordScopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
+    expect(lines[5][0]).toEqual value: '}', scopes: recordScopes.concat(['punctuation.section.class.end.bracket.curly.java'])
+
+    methodScopes = recordScopes.concat(['meta.record.body.java', 'meta.method.java'])
+    expect(lines[1][1]).toEqual value: 'public', scopes: methodScopes.concat(['storage.modifier.java'])
+    expect(lines[1][3]).toEqual value: 'Point', scopes: methodScopes.concat(['meta.method.identifier.java', 'entity.name.function.java'])
+    expect(lines[1][5]).toEqual value: '{', scopes: methodScopes.concat(['punctuation.section.method.begin.bracket.curly.java'])
+    expect(lines[2][1]).toEqual value: '//', scopes: methodScopes.concat(['meta.method.body.java', 'comment.line.double-slash.java', 'punctuation.definition.comment.java'])
+    expect(lines[3][1]).toEqual value: '}', scopes: methodScopes.concat(['punctuation.section.method.end.bracket.curly.java'])
+    expect(lines[4][1]).toEqual value: 'private', scopes: methodScopes.concat(['storage.modifier.java'])
+    expect(lines[4][3]).toEqual value: 'void', scopes: methodScopes.concat(['meta.method.return-type.java', 'storage.type.primitive.java'])
+    expect(lines[4][5]).toEqual value: 'foo', scopes: methodScopes.concat(['meta.method.identifier.java', 'entity.name.function.java'])
+
+  it 'tokenizes Java 14 record as an inner class', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        record Point() {}
+      }
+    '''
+
+    scopes = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.record.java']
+    expect(lines[1][1]).toEqual value: 'record', scopes: scopes.concat(['meta.record.identifier.java', 'storage.modifier.java'])
+    expect(lines[1][3]).toEqual value: 'Point', scopes: scopes.concat(['meta.record.identifier.java', 'entity.name.type.record.java'])
+    expect(lines[1][4]).toEqual value: '(', scopes: scopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.begin.bracket.round.java'])
+    expect(lines[1][5]).toEqual value: ')', scopes: scopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
+    expect(lines[1][7]).toEqual value: '{', scopes: scopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
+    expect(lines[1][8]).toEqual value: '}', scopes: scopes.concat(['punctuation.section.class.end.bracket.curly.java'])


### PR DESCRIPTION
### Description of the Change
Support "record" for Java 14, see #223 . Below are covered cases. 
```
1. basic declaration
record Point() {}

2. having record constructor, meanwhile not breaking member functions
public record Point(int x, int y) {
  public Point {
    // validation
  }
  private void foo() { }
}

3. implemeting interfaces
public record Point(int x) implements IA, IB {}

4. defined inner another class
class A {
  record Point() {}
}
```
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

N/A
### Benefits
Support to hightlight 'record'
### Possible Drawbacks
new rules are limited to 'record' declarations, and are supposed not to causing any no regression.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
Closes #223 
<!-- Enter any applicable Issues here -->
