### PR TITLE
Fix the scope of "instanceof" when using with camelCase variable names

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -1593,11 +1593,13 @@
   'variables':
     'begin': '''(?x)
       (?=
+        \\b
         (
-          \\b(void|boolean|byte|char|short|int|float|long|double)\\b
+          (void|boolean|byte|char|short|int|float|long|double)
           |
           (?>(\\w+\\.)*[A-Z_]+\\w*) # e.g. `javax.ws.rs.Response`, or `String`
         )
+        \\b
         \\s*
         (
           <[\\w<>,\\.?\\s\\[\\]]*> # e.g. `HashMap<Integer, String>`, or `List<java.lang.String>`

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1931,6 +1931,29 @@ describe 'Java grammar', ->
     expect(lines[3][5]).toEqual value: 'instanceof', scopes: scopeStack.concat ['keyword.operator.instanceof.java']
     expect(lines[6][4]).toEqual value: 'instanceof', scopes: scopeStack.concat ['meta.declaration.assertion.java', 'keyword.operator.instanceof.java']
 
+  it 'tokenizes the `instanceof` operator in return statements and variable definitions', ->
+    lines = grammar.tokenizeLines '''
+      class A {
+        boolean func1() {
+          return aa instanceof Test;
+        }
+
+        boolean func2() {
+          return aaBB instanceof Test;
+        }
+
+        void func3() {
+          boolean test = aB instanceof Test;
+        }
+      }
+      '''
+
+    expected = ['source.java', 'meta.class.java', 'meta.class.body.java', 'meta.method.java', 'meta.method.body.java', 'keyword.operator.instanceof.java']
+
+    expect(lines[2][3]).toEqual value: 'instanceof', scopes: expected
+    expect(lines[6][3]).toEqual value: 'instanceof', scopes: expected
+    expect(lines[10][7]).toEqual value: 'instanceof', scopes: expected
+
   it 'tokenizes class fields', ->
     lines = grammar.tokenizeLines '''
       class Test

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -1939,11 +1939,11 @@ describe 'Java grammar', ->
         }
 
         boolean func2() {
-          return aaBB instanceof Test;
+          return aaBbb instanceof Test;
         }
 
         void func3() {
-          boolean test = aB instanceof Test;
+          boolean test = aaBbb instanceof Test;
         }
       }
       '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR updates `variables` scope to restrict it to the word boundaries. This fixes the case when anything that could potentially match a variable declaration would break syntax highlighting, for example, `myVar instanceof MyClass` would result being highlighted as `my[Var instanceof MyClass]` where `[..]` would become a part of variable declaration.

I generalised the word boundary (`\b`) check to make sure we never match variable declaration halfway through, particularly for usages of `instanceof`.

### Alternate Designs

None were considered.

### Benefits

Fixes the issue of highlighting `instanceof`.

### Possible Drawbacks

This might break certain usages of variable declarations.

### Applicable Issues

Fixes #229 
