### PR TITLE
Add support for "yield", "sealed", and "permits" Java keywords

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -38,8 +38,8 @@
                     (abstract|assert|boolean|break|byte|case|catch|char|class|
                     const|continue|default|do|double|else|enum|extends|final|
                     finally|float|for|goto|if|implements|import|instanceof|int|
-                    interface|long|native|new|package|private|protected|public|
-                    return|short|static|strictfp|super|switch|syncronized|this|
+                    interface|long|native|new|package|permits|private|protected|public|
+                    return|sealed|short|static|strictfp|super|switch|syncronized|this|
                     throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
                   '''
@@ -86,8 +86,8 @@
                     (abstract|assert|boolean|break|byte|case|catch|char|class|
                     const|continue|default|do|double|else|enum|extends|final|
                     finally|float|for|goto|if|implements|import|instanceof|int|
-                    interface|long|native|new|package|private|protected|public|
-                    return|short|static|strictfp|super|switch|syncronized|this|
+                    interface|long|native|new|package|permits|private|protected|public|
+                    return|sealed|short|static|strictfp|super|switch|syncronized|this|
                     throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
                   '''
@@ -307,7 +307,7 @@
         'beginCaptures':
           '0':
             'name': 'storage.modifier.extends.java'
-        'end': '(?={|implements)'
+        'end': '(?={|implements|permits)'
         'name': 'meta.definition.class.inherited.classes.java'
         'patterns': [
           {
@@ -323,8 +323,24 @@
         'beginCaptures':
           '1':
             'name': 'storage.modifier.implements.java'
-        'end': '(?=\\s*extends|\\{)'
+        'end': '(?=\\s*extends|permits|\\{)'
         'name': 'meta.definition.class.implemented.interfaces.java'
+        'patterns': [
+          {
+            'include': '#object-types-inherited'
+          }
+          {
+            'include': '#comments'
+          }
+        ]
+      }
+      {
+        'begin': '(permits)\\s'
+        'beginCaptures':
+          '1':
+            'name': 'storage.modifier.permits.java'
+        'end': '(?=\\s*extends|implements|\\{)'
+        'name': 'meta.definition.class.permits.classes.java'
         'patterns': [
           {
             'include': '#object-types-inherited'
@@ -1391,7 +1407,7 @@
       }
     ]
   'storage-modifiers':
-    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp)\\b'
+    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp|sealed)\\b'
     'name': 'storage.modifier.java'
   'strings':
     'patterns': [

--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -40,7 +40,7 @@
                     finally|float|for|goto|if|implements|import|instanceof|int|
                     interface|long|native|new|package|private|protected|public|
                     return|short|static|strictfp|super|switch|syncronized|this|
-                    throw|throws|transient|try|void|volatile|while|
+                    throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
                   '''
         'name': 'invalid.illegal.character_not_allowed_here.java'
@@ -88,7 +88,7 @@
                     finally|float|for|goto|if|implements|import|instanceof|int|
                     interface|long|native|new|package|private|protected|public|
                     return|short|static|strictfp|super|switch|syncronized|this|
-                    throw|throws|transient|try|void|volatile|while|
+                    throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
                   '''
         'name': 'invalid.illegal.character_not_allowed_here.java'
@@ -791,7 +791,7 @@
         'name': 'keyword.control.ternary.java'
       }
       {
-        'match': '\\b(return|break|case|continue|default|do|while|for|switch|if|else)\\b'
+        'match': '\\b(return|yield|break|case|continue|default|do|while|for|switch|if|else)\\b'
         'name': 'keyword.control.java'
       }
       {

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -3099,3 +3099,23 @@ describe 'Java grammar', ->
       '''
 
     expect(lines[4][1]).toEqual value: 'yield', scopes: ['source.java', 'keyword.control.java']
+
+  it 'tokenizes sealed and permits keywords', ->
+    lines = grammar.tokenizeLines '''
+      public sealed class X extends A implements B permits C { }
+      public sealed class X permits A extends B implements C { }
+      public sealed class X implements A permits B extends C { }
+      public sealed class Shape permits Circle, Rectangle, Square { }
+      public sealed interface ConstantDesc permits String, Integer { }
+      '''
+
+    expect(lines[0][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
+    expect(lines[0][16]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
+    expect(lines[1][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
+    expect(lines[1][8]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
+    expect(lines[2][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
+    expect(lines[2][12]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
+    expect(lines[3][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
+    expect(lines[3][8]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
+    expect(lines[4][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
+    expect(lines[4][8]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -3085,3 +3085,17 @@ describe 'Java grammar', ->
     expect(lines[1][5]).toEqual value: ')', scopes: scopes.concat(['meta.record.identifier.java', 'punctuation.definition.parameters.end.bracket.round.java'])
     expect(lines[1][7]).toEqual value: '{', scopes: scopes.concat(['meta.record.body.java', 'punctuation.section.class.begin.bracket.curly.java'])
     expect(lines[1][8]).toEqual value: '}', scopes: scopes.concat(['punctuation.section.class.end.bracket.curly.java'])
+
+  it 'tokenizes yield keyword', ->
+    lines = grammar.tokenizeLines '''
+      public static int calculate(int d) {
+        return switch (d) {
+          default -> {
+            int l = d.toString().length();
+            yield l*l;
+          }
+        };
+      }
+      '''
+
+    expect(lines[4][1]).toEqual value: 'yield', scopes: ['source.java', 'keyword.control.java']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds support for JDK 13+ keywords:
- `yield`
- `sealed`
- `permits`

`yield` keyword is similar to `return`, so it is handled as "keyword.control.java". `sealed` and `permits` are only for classes and interfaces: `sealed` keyword is a "storage.modifier.java" and `permits` is handled similar to `extends` and `implements` keywords.

### Alternate Designs

No alternative designs were considered.

### Benefits

Fixes highlighting of the aforementioned keywords.

### Possible Drawbacks

Might potentially break class `extends` and `implements` scopes, but that would have to be a corner case not handled by unit tests. 

### Applicable Issues

Fixes #230 
Fixes #232 
