### PR TITLE
Add support for non-sealed keyword

### DIFF
--- a/grammars/java.cson
+++ b/grammars/java.cson
@@ -38,7 +38,7 @@
                     (abstract|assert|boolean|break|byte|case|catch|char|class|
                     const|continue|default|do|double|else|enum|extends|final|
                     finally|float|for|goto|if|implements|import|instanceof|int|
-                    interface|long|native|new|package|permits|private|protected|public|
+                    interface|long|native|new|non-sealed|package|permits|private|protected|public|
                     return|sealed|short|static|strictfp|super|switch|syncronized|this|
                     throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
@@ -86,7 +86,7 @@
                     (abstract|assert|boolean|break|byte|case|catch|char|class|
                     const|continue|default|do|double|else|enum|extends|final|
                     finally|float|for|goto|if|implements|import|instanceof|int|
-                    interface|long|native|new|package|permits|private|protected|public|
+                    interface|long|native|new|non-sealed|package|permits|private|protected|public|
                     return|sealed|short|static|strictfp|super|switch|syncronized|this|
                     throw|throws|transient|try|void|volatile|while|yield|
                     true|false|null)\\b
@@ -277,7 +277,7 @@
       }
     ]
   'class':
-    'begin': '(?=\\w?[\\w\\s]*\\b(?:class|(?<!@)interface|enum)\\s+[\\w$]+)'
+    'begin': '(?=\\w?[\\w\\s-]*\\b(?:class|(?<!@)interface|enum)\\s+[\\w$]+)'
     'end': '}'
     'endCaptures':
       '0':
@@ -1407,7 +1407,7 @@
       }
     ]
   'storage-modifiers':
-    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp|sealed)\\b'
+    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient|volatile|default|strictfp|sealed|non-sealed)\\b'
     'name': 'storage.modifier.java'
   'strings':
     'patterns': [

--- a/spec/java-spec.coffee
+++ b/spec/java-spec.coffee
@@ -3101,13 +3101,14 @@ describe 'Java grammar', ->
 
     expect(lines[4][1]).toEqual value: 'yield', scopes: ['source.java', 'keyword.control.java']
 
-  it 'tokenizes sealed and permits keywords', ->
+  it 'tokenizes sealed, non-sealed, and permits keywords', ->
     lines = grammar.tokenizeLines '''
       public sealed class X extends A implements B permits C { }
       public sealed class X permits A extends B implements C { }
       public sealed class X implements A permits B extends C { }
       public sealed class Shape permits Circle, Rectangle, Square { }
       public sealed interface ConstantDesc permits String, Integer { }
+      public non-sealed class Square extends Shape {}
       '''
 
     expect(lines[0][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
@@ -3120,3 +3121,4 @@ describe 'Java grammar', ->
     expect(lines[3][8]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
     expect(lines[4][2]).toEqual value: 'sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']
     expect(lines[4][8]).toEqual value: 'permits', scopes: ['source.java', 'meta.class.java', 'meta.definition.class.permits.classes.java', 'storage.modifier.permits.java']
+    expect(lines[5][2]).toEqual value: 'non-sealed', scopes: ['source.java', 'meta.class.java', 'storage.modifier.java']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds `non-sealed` keyword as a follow-up to #234.
I also had to update the class pattern to capture `-` that is in the keyword.

### Alternate Designs

N/A.

### Benefits

Adds support for `non-sealed` keyword.

### Possible Drawbacks

N/A.

### Applicable Issues

Fixes #236
