### PR TITLE
Fix tree-sitter constants

### DIFF
--- a/grammars/tree-sitter-java.cson
+++ b/grammars/tree-sitter-java.cson
@@ -292,9 +292,9 @@ scopes:
   method_reference > identifier,
   method_invocation > identifier
   ''': [
-    {match: '^[A-Z][A-Z_]+$', scopes: 'constant.other'},
+    {match: '^[A-Z][A-Z0-9_\\$]+$', scopes: 'constant.other'},
     {match: '^[A-Z]', scopes: 'storage.type'}
   ]
   'identifier': [
-    {match: '^[A-Z][A-Z_]+$', scopes: 'constant.other'}
+    {match: '^[A-Z][A-Z0-9_\\$]+$', scopes: 'constant.other'}
   ]

--- a/spec/tree-sitter-java-spec.coffee
+++ b/spec/tree-sitter-java-spec.coffee
@@ -246,12 +246,18 @@ describe 'Tree-sitter based Java grammar', ->
       a = CONSTANT + obj.func();
       b = conf.get(CONSTANT_ANOTHER);
       c = Integer.MAX_VALUE;
+      d = A1_B2_C3;
+      e = A1_B2_C$;
+      f = Test.A1_B2_C3;
     '''
 
     expect(tokens[0][2]).toEqual value: 'CONSTANT_STR', scopes: ['source.java', 'constant.other']
     expect(tokens[1][3]).toEqual value: 'CONSTANT', scopes: ['source.java', 'constant.other']
     expect(tokens[2][6]).toEqual value: 'CONSTANT_ANOTHER', scopes: ['source.java', 'constant.other']
     expect(tokens[3][5]).toEqual value: 'MAX_VALUE', scopes: ['source.java', 'constant.other']
+    expect(tokens[4][3]).toEqual value: 'A1_B2_C3', scopes: ['source.java', 'constant.other']
+    expect(tokens[5][3]).toEqual value: 'A1_B2_C$', scopes: ['source.java', 'constant.other']
+    expect(tokens[6][5]).toEqual value: 'A1_B2_C3', scopes: ['source.java', 'constant.other']
 
   it 'tokenizes reserved keywords', ->
     tokens = tokenizeLine 'const value;'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes syntax highlighting for constants when using tree-sitter.
Examples that are fixed now:
```java
d = A1_B2_C3;
e = A1_B2_C$;
f = Test.A1_B2_C3;
```
### Alternate Designs

N/A

### Benefits

N/A

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Fixes #240 
