### PR TITLE
Fix tree-sitter annotations

### DIFF
--- a/grammars/tree-sitter-java.cson
+++ b/grammars/tree-sitter-java.cson
@@ -253,11 +253,17 @@ scopes:
 
   'marker_annotation': 'meta.declaration.annotation'
   'marker_annotation > "@"': 'punctuation.definition.annotation'
-  'marker_annotation > identifier': 'storage.type.annotation'
+  '''
+  marker_annotation > identifier,
+  marker_annotation > scoped_identifier > identifier
+  ''': 'storage.type.annotation'
 
   'annotation': 'meta.declaration.annotation'
   'annotation > "@"': 'punctuation.definition.annotation'
-  'annotation > identifier': 'storage.type.annotation'
+  '''
+  annotation > identifier,
+  annotation > scoped_identifier > identifier
+  ''': 'storage.type.annotation'
 
   'element_value_pair > identifier': 'variable.other.annotation.element'
 

--- a/spec/tree-sitter-java-spec.coffee
+++ b/spec/tree-sitter-java-spec.coffee
@@ -900,6 +900,8 @@ describe 'Tree-sitter based Java grammar', ->
       @Annotation2()
       @Annotation3("value")
       @Annotation4(key = "value")
+      @Test.Annotation5
+      @Test.Annotation6()
       class A { }
     '''
 
@@ -924,6 +926,18 @@ describe 'Tree-sitter based Java grammar', ->
     expect(tokens[3][5]).toEqual value: '=', scopes: ['source.java', 'meta.declaration.annotation', 'keyword.operator.assignment']
     expect(tokens[3][7]).toEqual value: '\"value\"', scopes: ['source.java', 'meta.declaration.annotation', 'string.quoted.double']
     expect(tokens[3][8]).toEqual value: ')', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.bracket.round']
+
+    expect(tokens[4][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.definition.annotation']
+    expect(tokens[4][1]).toEqual value: 'Test', scopes: ['source.java', 'meta.declaration.annotation', 'storage.type.annotation']
+    expect(tokens[4][2]).toEqual value: '.', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.separator.period']
+    expect(tokens[4][3]).toEqual value: 'Annotation5', scopes: ['source.java', 'meta.declaration.annotation', 'storage.type.annotation']
+
+    expect(tokens[5][0]).toEqual value: '@', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.definition.annotation']
+    expect(tokens[5][1]).toEqual value: 'Test', scopes: ['source.java', 'meta.declaration.annotation', 'storage.type.annotation']
+    expect(tokens[5][2]).toEqual value: '.', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.separator.period']
+    expect(tokens[5][3]).toEqual value: 'Annotation6', scopes: ['source.java', 'meta.declaration.annotation', 'storage.type.annotation']
+    expect(tokens[5][4]).toEqual value: '(', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.bracket.round']
+    expect(tokens[5][5]).toEqual value: ')', scopes: ['source.java', 'meta.declaration.annotation', 'punctuation.bracket.round']
 
   it 'tokenizes constructor declarations', ->
     tokens = tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR adds missing annotations with scoped identifiers. Previously we only handled single identifiers.
This fixes the following cases:
```java
class A {
  @Test.Annotation
  @Test.Annotation()
  void func() {
    // test
  }
}
```

### Alternate Designs

N/A

### Benefits

N/A

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Fixes #239 
