### PR TITLE
Install the exact version instead of range

### DIFF
--- a/grammars/tree-sitter-java.cson
+++ b/grammars/tree-sitter-java.cson
@@ -1,7 +1,7 @@
 name: 'Java'
 scopeName: 'source.java'
 type: 'tree-sitter'
-parser: 'tree-sitter-java-dev'
+parser: 'tree-sitter-java'
 
 fileTypes: [
   'java'

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,12 +145,12 @@
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
-    "tree-sitter-java-dev": {
-      "version": "0.16.0-dev2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-java-dev/-/tree-sitter-java-dev-0.16.0-dev2.tgz",
-      "integrity": "sha512-BilPJ2SwvRKMTeq2WZdvVX5HiMYTLSncJATkqWiPRGUl157FcBjY42mzm3M42/5QQybb1nDJjW0tAvVA5iEHmw==",
+    "tree-sitter-java": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.19.1.tgz",
+      "integrity": "sha512-yVm+4q1D4niaHcEf2iqhOcIaiSp3wxHjeC4eoLAqSQNVxSrhThmT1FEfM4yDgHV4XaxH+62xpKHCwYG9NzRt6Q==",
       "requires": {
-        "nan": "^2.12.1"
+        "nan": "^2.14.1"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-java/issues"
   },
   "dependencies": {
-    "tree-sitter-java-dev": "^0.16.0-dev2"
+    "tree-sitter-java": "0.19.1"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
`^version` means install any version that is compatible with the range.
This means npm can even install tree-sitter-javascript version 0.15
since in semver 0.15 should be compatible with 0.19. tree-sitter seems
to have broken semver. 0.15 is not compatible with 0.19
