### PR TITLE
Update the tree-sitter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,9 +104,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -146,11 +146,10 @@
       "dev": true
     },
     "tree-sitter-java-dev": {
-      "version": "0.16.0-dev2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-java-dev/-/tree-sitter-java-dev-0.16.0-dev2.tgz",
-      "integrity": "sha512-BilPJ2SwvRKMTeq2WZdvVX5HiMYTLSncJATkqWiPRGUl157FcBjY42mzm3M42/5QQybb1nDJjW0tAvVA5iEHmw==",
+      "version": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3",
+      "from": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3",
       "requires": {
-        "nan": "^2.12.1"
+        "nan": "^2.14.1"
       }
     },
     "wordwrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,8 +146,8 @@
       "dev": true
     },
     "tree-sitter-java-dev": {
-      "version": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3",
-      "from": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3",
+      "version": "git+https://github.com/icecream17/tree-sitter-java.git#cd65bb4cce7b2ba4f444aadd2202b12c484de036",
+      "from": "git+https://github.com/icecream17/tree-sitter-java.git#cd65bb4cce7b2ba4f444aadd2202b12c484de036",
       "requires": {
         "nan": "^2.14.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-java/issues"
   },
   "dependencies": {
-    "tree-sitter-java-dev": "^0.16.0-dev2"
+    "tree-sitter-java-dev": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-java/issues"
   },
   "dependencies": {
-    "tree-sitter-java-dev": "git+https://github.com/icecream17/tree-sitter-java.git#97035a3aeeff1af5af07e072c28c43b7f69321a3"
+    "tree-sitter-java-dev": "git+https://github.com/icecream17/tree-sitter-java.git#cd65bb4cce7b2ba4f444aadd2202b12c484de036"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
### Description of the Change

Updates tree-sitter-java to v19

Or rather, a fork of tree-sitter-java.
So now I made a fork that combines v19 and the old fork together.

https://github.com/tree-sitter/tree-sitter-java/compare/master...icecream17:cd65bb4cce7b2ba4f444aadd2202b12c484de036
https://github.com/tree-sitter/tree-sitter-java/compare/master...sadikovi:master

My fork passes the [tests on the tree-sitter-java repo](https://github.com/icecream17/tree-sitter-java/runs/5026487832),
but _not [the tests on this repo](https://github.com/icecream17/language-java/runs/5026539450)_.

Part of https://github.com/atom/atom/issues/22129 and https://github.com/icecream17/atom-update-backlog/blob/main/Languages.md

Don't merge yet

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

https://github.com/atom/atom/issues/22129
<!-- Enter any applicable Issues here -->
